### PR TITLE
Follow nap's lead (see websdk/nap#27)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,18 @@
-PATH  := node_modules/.bin:$(PATH)
 SHELL := /bin/bash
+PATH  := $(shell echo $${PATH//\.\/node_modules\/\.bin:/}):node_modules/.bin
 
 SRC = $(wildcard src/*.js)
 LIB = $(SRC:src/%.js=lib/%.js)
 TST = $(wildcard test/*.js) $(wildcard test/**/*.js)
-NPM = @npm install --local > /dev/null && touch node_modules
+NPM = @npm install --local && touch node_modules
+OPT = --plugins transform-es2015-modules-umd --copy-files --source-maps
 
 v  ?= patch
 
 build: node_modules $(LIB)
 lib/%.js: src/%.js
 	@mkdir -p $(@D)
-	@browserify $< --standalone $(@F:%.js=%) | uglifyjs -o $@
+	@babel $(OPT) -o $@ $<
 
 node_modules: package.json
 	$(NPM)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "URL routing in js",
   "main": "lib/rhumb.js",
   "devDependencies": {
-    "browserify": "11.1.0",
+    "babel-cli": "6.1.4",
+    "babel-plugin-transform-es2015-modules-umd": "6.1.4",
     "coveralls": "2.11.4",
     "nodemon": "1.7.1",
     "nyc": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websdk/rhumb",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "URL routing in js",
   "main": "lib/rhumb.js",
   "devDependencies": {


### PR DESCRIPTION
This replaces browserify with babel, for all the same reasons as in websdk/nap#27.