### PR TITLE
Add support for root paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PATH  := $(shell echo $${PATH//\.\/node_modules\/\.bin:/}):node_modules/.bin
 SRC = $(wildcard src/*.js)
 LIB = $(SRC:src/%.js=lib/%.js)
 TST = $(wildcard test/*.js) $(wildcard test/**/*.js)
-NPM = @npm install --local && touch node_modules
+NPM = @npm install --local
 OPT = --plugins transform-es2015-modules-umd --copy-files --source-maps
 
 v  ?= patch

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websdk/rhumb",
-  "version": "0.3.9-support-root-paths.0",
+  "version": "0.3.9-support-root-paths.1",
   "description": "URL routing in js",
   "main": "lib/rhumb.js",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websdk/rhumb",
-  "version": "0.3.8",
+  "version": "0.3.9-support-root-paths.0",
   "description": "URL routing in js",
   "main": "lib/rhumb.js",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websdk/rhumb",
-  "version": "0.3.9-support-root-paths.1",
+  "version": "0.3.9",
   "description": "URL routing in js",
   "main": "lib/rhumb.js",
   "devDependencies": {

--- a/src/rhumb.js
+++ b/src/rhumb.js
@@ -57,10 +57,6 @@ function create (){
       , peek
 
     if (Array.isArray(part)) {
-      if (node.leaf) {
-        throw new Error('Ambiguous')
-      }
-
       node.leaf = fn
       updateTree(part, node, fn)
       return

--- a/test/parsing/fixed-paths.test.js
+++ b/test/parsing/fixed-paths.test.js
@@ -1,12 +1,21 @@
 var test  = require('tape')
   , rhumb = require('../../src/rhumb')
 
+var root = { type: 'fixed', input: '/' }
+
+test('Parsing should always infer root', function(t) {
+  t.plan(2)
+
+  t.deepEqual(rhumb._parse(''), [ root ])
+  t.deepEqual(rhumb._parse('/'), [ root ])
+})
+
 test("Parsing should find one fixed part", function(t) {
   var out = rhumb._parse("/foo")
 
   t.plan(1)
   t.deepEqual(out,
-    [ { type: "fixed", input: "foo" } ]
+    [ root, { type: "fixed", input: "foo" } ]
   )
 })
 
@@ -15,17 +24,19 @@ test("Parsing should find multiple fixed parts", function(t) {
 
   t.plan(1)
   t.deepEqual(out,
-    [ { type: "fixed", input: "foo"  }
+    [ root
+    , { type: "fixed", input: "foo"  }
     , { type: "fixed", input: "bar"  }
     , { type: "fixed", input: "bing" }
     ]
   )
 })
+
 test("Parsing should find single fixed part for /", function(t) {
   var out = rhumb._parse("/")
 
   t.plan(1)
   t.deepEqual(out,
-    [ { type: "fixed", input: "" } ]
+    [ root ]
   )
 })

--- a/test/parsing/optional-paths.test.js
+++ b/test/parsing/optional-paths.test.js
@@ -1,13 +1,16 @@
 var test  = require('tape')
   , rhumb = require('../../src/rhumb')
 
+var root = { type: 'fixed', input: '/' }
+
 test("Parsing should find optional part at end of path", function(t){
   var out = rhumb._parse("/one/two(/three)")
 
   t.plan(2)
   t.ok(out)
   t.deepEqual(out,
-    [ { type: "fixed", input: "one"}
+    [ root
+    , { type: "fixed", input: "one"}
     , { type: "fixed", input: "two"}
     , [ { type: "fixed", input: "three"} ]
     ]
@@ -20,7 +23,8 @@ test("Parsing should find nested optional elements at end of path", function(t){
   t.plan(2)
   t.ok(out)
   t.deepEqual(out,
-    [ { type: "fixed", input: "one"}
+    [ root
+    , { type: "fixed", input: "one"}
     , { type: "fixed", input: "two"}
     , [ { type: "fixed", input: "three"}
       , { type: "fixed", input: "four"}

--- a/test/parsing/partially-variable-paths.test.js
+++ b/test/parsing/partially-variable-paths.test.js
@@ -1,27 +1,38 @@
 var test  = require('tape')
   , rhumb = require('../../src/rhumb')
 
+var root = { type: 'fixed', input: '/' }
+
 test("Parsing should find a partial part with fixed left and right", function(t) {
   var out = rhumb._parse("/left{page}right")
 
-  t.plan(3)
+  t.plan(6)
   t.ok(out)
-  t.equal(out.length, 1)
-  t.equal(out[0].type, "partial")
+  t.equal(out.length, 2)
+  t.deepEqual(out[0], root)
+  t.equal(out[1].name, 'left{var}right')
+  t.equal(out[1].type, 'partial')
+  t.deepEqual(out[1].vars, ['page'])
 })
 test("Parsing should find a partial part with fixed right", function(t) {
   var out = rhumb._parse("/{page}right")
 
-  t.plan(3)
+  t.plan(6)
   t.ok(out)
-  t.equal(out.length, 1)
-  t.equal(out[0].type, "partial")
+  t.equal(out.length, 2)
+  t.deepEqual(out[0], root)
+  t.equal(out[1].name, '{var}right')
+  t.equal(out[1].type, 'partial')
+  t.deepEqual(out[1].vars, ['page'])
 })
 test("Parsing should find a partial part with fixed left", function(t) {
   var out = rhumb._parse("/left{page}")
 
-  t.plan(3)
+  t.plan(6)
   t.ok(out)
-  t.equal(out.length, 1)
-  t.equal(out[0].type, "partial")
+  t.equal(out.length, 2)
+  t.deepEqual(out[0], root)
+  t.equal(out[1].name, 'left{var}')
+  t.equal(out[1].type, 'partial')
+  t.deepEqual(out[1].vars, ['page'])
 })

--- a/test/parsing/variable-paths.test.js
+++ b/test/parsing/variable-paths.test.js
@@ -1,13 +1,15 @@
 var test  = require('tape')
   , rhumb = require('../../src/rhumb')
 
+var root = { type: 'fixed', input: '/' }
+
 test("Parsing should find single variable part", function(t) {
   var out = rhumb._parse("/{wibble}")
 
   t.plan(2)
   t.ok(out)
   t.deepEqual(out,
-    [ { type: "var", input: "wibble" } ]
+    [ root, { type: "var", input: "wibble" } ]
   )
 })
 
@@ -17,7 +19,8 @@ test("Parsing should find multiple variable parts", function(t) {
   t.plan(2)
   t.ok(out)
   t.deepEqual(out,
-    [ { type: "var", input: "wibble" }
+    [ root
+    , { type: "var", input: "wibble" }
     , { type: "var", input: "wobble" }
     ]
   )
@@ -29,7 +32,8 @@ test("Parsing should find variable and fixed parts", function(t) {
   t.plan(2)
   t.ok(out)
   t.deepEqual(out,
-    [ { type: "var", input: "wibble" }
+    [ root
+    , { type: "var", input: "wibble" }
     , { type: "fixed", input: "bar" }
     , { type: "var", input: "wobble" }
     ]

--- a/test/routing/ambiguity.test.js
+++ b/test/routing/ambiguity.test.js
@@ -1,6 +1,28 @@
 var test  = require('tape')
   , rhumb = require('../../src/rhumb')
 
+test('Routing should detect /foo and (/foo) as ambiguous', function(t) {
+  t.plan(1)
+  var router = rhumb.create()
+
+  router.add('/foo', function() {})
+
+  t.throws(function() {
+    router.add('(/foo)', function() {})
+  })
+})
+
+test('Routing should detect /foo and /foo as ambiguous', function(t) {
+  t.plan(1)
+  var router = rhumb.create()
+
+  router.add('/foo', function() {})
+
+  t.throws(function() {
+    router.add('/foo', function() {})
+  })
+})
+
 test("Routing should detect /foo/{bar} and /foo(/{maybe}) as ambiguous", function(t) {
   t.plan(1)
   var router = rhumb.create()

--- a/test/routing/ambiguity.test.js
+++ b/test/routing/ambiguity.test.js
@@ -23,13 +23,91 @@ test('Routing should detect /foo and /foo as ambiguous', function(t) {
   })
 })
 
+test("Routing should detect /foo/{bar} and /foo/{maybe} as ambiguous", function(t) {
+  t.plan(1)
+  var router = rhumb.create()
+
+  router.add("/foo/{bar}", function() {})
+
+  t.throws(function() {
+    router.add("/foo/{maybe}", function() {})
+  })
+})
+
 test("Routing should detect /foo/{bar} and /foo(/{maybe}) as ambiguous", function(t) {
   t.plan(1)
   var router = rhumb.create()
 
-  router.add("/foo/{bar})", function() {})
+  router.add("/foo/{bar}", function() {})
 
   t.throws(function() {
-    router.add("/foo/{maybe})", function() {})
+    router.add("/foo(/{maybe})", function() {})
+  })
+})
+
+test("Routing should detect /foo/{bar} and /foo/{maybe} as ambiguous", function(t) {
+  t.plan(1)
+  var router = rhumb.create()
+
+  router.add("/foo(/{bar})", function() {})
+
+  t.throws(function() {
+    router.add("/foo/{maybe}", function() {})
+  })
+})
+
+test("Routing should detect /foo(/{bar}) and /foo(/{maybe}) as ambiguous", function(t) {
+  t.plan(1)
+  var router = rhumb.create()
+
+  router.add("/foo(/{bar})", function() {})
+
+  t.throws(function() {
+    router.add("/foo(/{maybe})", function() {})
+  })
+})
+
+
+test("Routing should detect /foo/moo{bar} and /foo/moo{maybe} as ambiguous", function(t) {
+  t.plan(1)
+  var router = rhumb.create()
+
+  router.add("/foo/moo{bar}", function() {})
+
+  t.throws(function() {
+    router.add("/foo/moo{maybe}", function() {})
+  })
+})
+
+test("Routing should detect /foo/moo{bar} and /foo(/moo{maybe}) as ambiguous", function(t) {
+  t.plan(1)
+  var router = rhumb.create()
+
+  router.add("/foo/moo{bar}", function() {})
+
+  t.throws(function() {
+    router.add("/foo(/moo{maybe})", function() {})
+  })
+})
+
+test("Routing should detect /foo/moo{bar} and /foo/moo{maybe} as ambiguous", function(t) {
+  t.plan(1)
+  var router = rhumb.create()
+
+  router.add("/foo(/moo{bar})", function() {})
+
+  t.throws(function() {
+    router.add("/foo/moo{maybe}", function() {})
+  })
+})
+
+test("Routing should detect /foo(/moo{bar}) and /foo(/moo{maybe}) as ambiguous", function(t) {
+  t.plan(1)
+  var router = rhumb.create()
+
+  router.add("/foo(/moo{bar})", function() {})
+
+  t.throws(function() {
+    router.add("/foo(/moo{maybe})", function() {})
   })
 })

--- a/test/routing/callback.test.js
+++ b/test/routing/callback.test.js
@@ -2,9 +2,13 @@ var test  = require('tape')
   , rhumb = require('../../src/rhumb')
 
 test("Routing should trigger callback and get return value", function(t) {
-  t.plan(2)
+  t.plan(3)
 
   var router = rhumb.create()
+
+  router.add('/', function() {
+    return 'slash triggered'
+  })
 
   router.add("/bar", function(){
     return "woo, bar triggered"
@@ -14,6 +18,7 @@ test("Routing should trigger callback and get return value", function(t) {
     return "bar/foo/farr triggered"
   })
 
+  t.equal(router.match('/'), 'slash triggered')
   t.equal(router.match("/bar/foo/farr"), "bar/foo/farr triggered")
   t.equal(router.match("/bar"), "woo, bar triggered")
 })

--- a/test/routing/not-found.test.js
+++ b/test/routing/not-found.test.js
@@ -1,0 +1,12 @@
+var test  = require('tape')
+  , rhumb = require('../../src/rhumb')
+
+test('Routing should return false when not finding things', function(t) {
+  t.plan(3)
+
+  var router = rhumb.create()
+
+  t.notOk(router.match('/'))
+  t.notOk(router.match("/bar/foo/farr"))
+  t.notOk(router.match("/bar"))
+})


### PR DESCRIPTION
This adds support for callacks registered at `/`, and also for
root level optional paths (e.g. `(/foo)`) with ambiguity detection
and all the goodness we've come to expect from rhumb.

This fixes #1.