### PR TITLE
Update parse to support empty parts and detect leading or trailing slashes

### DIFF
--- a/src/rhumb.js
+++ b/src/rhumb.js
@@ -50,7 +50,7 @@ function create() {
   var router = {}
     , tree = {}
 
-  function updateTree(part, node, fn) {
+  function updateTree(part, node, route, fn) {
     var segment = part.segments.shift()
       , more = !!part.segments.length
       , peek
@@ -69,7 +69,7 @@ function create() {
         throw new Error('Ambiguity')
       }
       node.leaf = fn
-      updateTree(segment, node, fn)
+      updateTree(segment, node, route, fn)
       return
     }
 
@@ -114,17 +114,17 @@ function create() {
         node.partial.tests.push(peek)
         break
       case 'empty':
-        throw new Error('Ambiguity')
+        throw new InvalidRouteException('Must not contain an empty segment', route)
     }
     if (!more) {
       peek.leaf = fn
     } else {
-      updateTree(part, peek, fn)
+      updateTree(part, peek, route, fn)
     }
   }
 
-  router.add = function (ptn, callback) {
-      updateTree(parse(ptn), tree, callback)
+  router.add = function (route, callback) {
+      updateTree(parse(route), tree, route, callback)
   }
 
   router.match = function(path){
@@ -141,6 +141,16 @@ function create() {
     }
   }
   return router
+}
+
+function InvalidRouteException(message, route) {
+  this.message = message
+  this.name = 'InvalidRouteException'
+  this.route = route
+
+  this.toString = function () {
+    return 'Invalid route: ' + message
+  }
 }
 
 function falsy(d){

--- a/src/rhumb.js
+++ b/src/rhumb.js
@@ -124,7 +124,11 @@ function create() {
   }
 
   router.add = function (route, callback) {
-      updateTree(parse(route), tree, route, callback)
+    var parsedRoute = parse(route)
+    if (Object.keys(parsedRoute.queryParams).length > 0) {
+      throw new InvalidRouteException('Must not contain a query string', route)
+    }
+    updateTree(parsedRoute, tree, route, callback)
   }
 
   router.match = function(path){
@@ -283,8 +287,14 @@ function parseOptional(ptn) {
   return parsedOutput
 }
 
-function parse(ptn){
-  return ptn.indexOf('(/') > -1 ? parseOptional(ptn) : parsePtn(ptn)
+function parse(route) {
+  var split = route.split('?')
+    , parsedPath = split[0].indexOf('(/') > -1
+        ? parseOptional(split[0])
+        : parsePtn(split[0])
+
+  parsedPath.queryParams = parseQueryString(split[1])
+  return parsedPath
 }
 
 var rhumb = create()

--- a/test/parsing/fixed-paths.test.js
+++ b/test/parsing/fixed-paths.test.js
@@ -1,42 +1,81 @@
 var test  = require('tape')
   , rhumb = require('../../src/rhumb')
+  , utils = require('../utils')
 
-var root = { type: 'fixed', input: '/' }
+test('Parsing handles empty path', function (t) {
+  t.plan(3)
 
-test('Parsing should always infer root', function(t) {
-  t.plan(2)
-
-  t.deepEqual(rhumb._parse(''), [ root ])
-  t.deepEqual(rhumb._parse('/'), [ root ])
+  t.deepEqual(rhumb._parse('').segments, [], 'no segments found')
+  t.notOk(rhumb._parse('').leadingSlash, 'has no leading slash')
+  t.notOk(rhumb._parse('').trailingSlash, 'has no trailing slash')
 })
 
-test("Parsing should find one fixed part", function(t) {
-  var out = rhumb._parse("/foo")
+test('Parsing handles the root path', function (t) {
+  t.plan(3)
 
-  t.plan(1)
-  t.deepEqual(out,
-    [ root, { type: "fixed", input: "foo" } ]
-  )
+  t.deepEqual(rhumb._parse('/').segments, [], 'no segments found')
+  t.ok(rhumb._parse('/').leadingSlash, 'has a leading slash')
+  t.ok(rhumb._parse('/').trailingSlash, 'has a trailing slash')
 })
 
-test("Parsing should find multiple fixed parts", function(t) {
-  var out = rhumb._parse("/foo/bar/bing")
+test('Parsing should find segments for a path with fixed segments', function (t) {
+  t.plan(12)
 
-  t.plan(1)
-  t.deepEqual(out,
-    [ root
-    , { type: "fixed", input: "foo"  }
-    , { type: "fixed", input: "bar"  }
-    , { type: "fixed", input: "bing" }
-    ]
-  )
+  t.deepEqual(rhumb._parse('/foo').segments, [utils.fixedSegment('foo')], 'one fixed segment found')
+  t.deepEqual(rhumb._parse('/foo/').segments, [utils.fixedSegment('foo')], 'one fixed segment found')
+  t.deepEqual(rhumb._parse('foo').segments, [utils.fixedSegment('foo')], 'one fixed segment found')
+  t.deepEqual(rhumb._parse('foo/').segments, [utils.fixedSegment('foo')], 'one fixed segment found')
+
+  var fooBarBingSegments = [utils.fixedSegment('foo'), utils.fixedSegment('bar'), utils.fixedSegment('bing')]
+  t.deepEqual(rhumb._parse('/foo/bar/bing').segments, fooBarBingSegments, 'three fixed segments found')
+  t.deepEqual(rhumb._parse('/foo/bar/bing/').segments, fooBarBingSegments, 'three fixed segments found')
+  t.deepEqual(rhumb._parse('foo/bar/bing').segments, fooBarBingSegments, 'three fixed segments found')
+  t.deepEqual(rhumb._parse('foo/bar/bing/').segments, fooBarBingSegments, 'three fixed segments found')
+
+  t.deepEqual(rhumb._parse('//').segments
+    , [utils.emptySegment()], 'empty segment found')
+  t.deepEqual(rhumb._parse('//bar/bing').segments
+    , [utils.emptySegment(), utils.fixedSegment('bar'), utils.fixedSegment('bing')], 'two fixed and one empty segment found')
+  t.deepEqual(rhumb._parse('foo//').segments
+    , [utils.fixedSegment('foo'), utils.emptySegment()], 'one fixed and one empty segment found')
+  t.deepEqual(rhumb._parse('foo//bing').segments
+    , [utils.fixedSegment('foo'), utils.emptySegment(), utils.fixedSegment('bing')], 'two fixed and one empty segment found')
 })
 
-test("Parsing should find single fixed part for /", function(t) {
-  var out = rhumb._parse("/")
+test('Parsing should identify whether a path with fixed segments has a leading slash', function (t) {
+  t.plan(12)
 
-  t.plan(1)
-  t.deepEqual(out,
-    [ root ]
-  )
+  t.ok(rhumb._parse('/foo').leadingSlash, 'has a leading slash')
+  t.ok(rhumb._parse('/foo/').leadingSlash, 'has a leading slash')
+  t.ok(rhumb._parse('/foo/bar/bing').leadingSlash, 'has a leading slash')
+  t.ok(rhumb._parse('/foo/bar/bing/').leadingSlash, 'has a leading slash')
+
+  t.notOk(rhumb._parse('foo').leadingSlash, 'has no leading slash')
+  t.notOk(rhumb._parse('foo/').leadingSlash, 'has no leading slash')
+  t.notOk(rhumb._parse('foo/bar/bing').leadingSlash, 'has no leading slash')
+  t.notOk(rhumb._parse('foo/bar/bing/').leadingSlash, 'has no leading slash')
+
+  t.ok(rhumb._parse('//').leadingSlash, 'has a leading slash')
+  t.ok(rhumb._parse('//bar/bing').leadingSlash, 'has a leading slash')
+  t.notOk(rhumb._parse('foo//').leadingSlash, 'has no leading slash')
+  t.notOk(rhumb._parse('foo//bing').leadingSlash, 'has no leading slash')
+})
+
+test('Parsing should identify whether a path with fixed segments has a trailing slash', function (t) {
+  t.plan(12)
+
+  t.notOk(rhumb._parse('/foo').trailingSlash, 'has no trailing slash')
+  t.notOk(rhumb._parse('/foo/bar/bing').trailingSlash, 'has no trailing slash')
+  t.notOk(rhumb._parse('foo').trailingSlash, 'has no trailing slash')
+  t.notOk(rhumb._parse('foo/bar/bing').trailingSlash, 'has no trailing slash')
+
+  t.ok(rhumb._parse('/foo/').trailingSlash, 'has a trailing slash')
+  t.ok(rhumb._parse('/foo/bar/bing/').trailingSlash, 'has a trailing slash')
+  t.ok(rhumb._parse('foo/').trailingSlash, 'has a trailing slash')
+  t.ok(rhumb._parse('foo/bar/bing/').trailingSlash, 'has a trailing slash')
+
+  t.ok(rhumb._parse('//').trailingSlash, 'has a trailing slash')
+  t.notOk(rhumb._parse('//bar/bing').trailingSlash, 'has no trailing slash')
+  t.ok(rhumb._parse('foo//').trailingSlash, 'has a trailing slash')
+  t.notOk(rhumb._parse('foo//bing').trailingSlash, 'has no trailing slash')
 })

--- a/test/parsing/partially-variable-paths.test.js
+++ b/test/parsing/partially-variable-paths.test.js
@@ -1,38 +1,78 @@
 var test  = require('tape')
   , rhumb = require('../../src/rhumb')
+  , utils = require('../utils')
 
-var root = { type: 'fixed', input: '/' }
+test('Parsing should find a partial part with fixed left and right', function (t) {
+  t.plan(7)
 
-test("Parsing should find a partial part with fixed left and right", function(t) {
-  var out = rhumb._parse("/left{page}right")
+  var results = rhumb._parse('/left{page}right')
+    , matchFunction = results.segments[0].matchFunction
 
-  t.plan(6)
-  t.ok(out)
-  t.equal(out.length, 2)
-  t.deepEqual(out[0], root)
-  t.equal(out[1].name, 'left{var}right')
-  t.equal(out[1].type, 'partial')
-  t.deepEqual(out[1].vars, ['page'])
+  t.deepEqual(results.segments, [
+    utils.partialSegment('left{var}right', ['page'], matchFunction)
+  ], 'has one partial segment with fixed left and right')
+
+  t.ok(rhumb._parse('/left{page}right').leadingSlash, 'has a leading slash')
+  t.notOk(rhumb._parse('/left{page}right').trailingSlash, 'has no trailing slash')
+
+  t.deepEqual(matchFunction('middleright'), null, 'when partial is not match no results are returned')
+  t.deepEqual(matchFunction('leftright'), null, 'when empty partial match no results are returned')
+  t.deepEqual(matchFunction('leftmiddleright'), { page: 'middle' }, 'match function finds word in middle')
+  t.deepEqual(matchFunction('left-middle-right'), { page: '-middle-' }, 'match function finds word in middle')
 })
-test("Parsing should find a partial part with fixed right", function(t) {
-  var out = rhumb._parse("/{page}right")
 
-  t.plan(6)
-  t.ok(out)
-  t.equal(out.length, 2)
-  t.deepEqual(out[0], root)
-  t.equal(out[1].name, '{var}right')
-  t.equal(out[1].type, 'partial')
-  t.deepEqual(out[1].vars, ['page'])
+test('Parsing should find a partial part with fixed right', function (t) {
+  t.plan(7)
+
+  var results = rhumb._parse('/{page}right')
+    , matchFunction = results.segments[0].matchFunction
+
+  t.deepEqual(results.segments, [
+    utils.partialSegment('{var}right', ['page'], matchFunction)
+  ], 'has one partial segment with fixed right')
+
+  t.ok(rhumb._parse('/{page}right').leadingSlash, 'has a leading slash')
+  t.notOk(rhumb._parse('/{page}right').trailingSlash, 'has no trailing slash')
+
+  t.deepEqual(matchFunction('left'), null, 'when partial is not match no results are returned')
+  t.deepEqual(matchFunction('right'), null, 'when empty partial match no results are returned')
+  t.deepEqual(matchFunction('leftright'), { page: 'left' }, 'match function finds word on the left')
+  t.deepEqual(matchFunction('left-middle-right'), { page: 'left-middle-' }, 'match function finds word on the left')
 })
-test("Parsing should find a partial part with fixed left", function(t) {
-  var out = rhumb._parse("/left{page}")
 
+test('Parsing should find a partial part with fixed left', function (t) {
+  t.plan(7)
+
+  var results = rhumb._parse('/left{page}')
+    , matchFunction = results.segments[0].matchFunction
+
+  t.deepEqual(results.segments, [
+    utils.partialSegment('left{var}', ['page'], matchFunction)
+  ], 'has one partial segment with fixed left')
+
+  t.ok(rhumb._parse('/left{page}').leadingSlash, 'has a leading slash')
+  t.notOk(rhumb._parse('/left{page}').trailingSlash, 'has no trailing slash')
+
+  t.deepEqual(matchFunction('right'), null, 'when partial is not match no results are returned')
+  t.deepEqual(matchFunction('left'), null, 'when empty partial match no results are returned')
+  t.deepEqual(matchFunction('leftright'), { page: 'right' }, 'match function finds word on the right')
+  t.deepEqual(matchFunction('left-middle-right'), { page: '-middle-right' }, 'match function finds word on the right')
+})
+
+test('Parsing should find a partial part with many variables', function (t) {
   t.plan(6)
-  t.ok(out)
-  t.equal(out.length, 2)
-  t.deepEqual(out[0], root)
-  t.equal(out[1].name, 'left{var}')
-  t.equal(out[1].type, 'partial')
-  t.deepEqual(out[1].vars, ['page'])
+
+  var results = rhumb._parse('/{day}-{month}-{year}')
+    , matchFunction = results.segments[0].matchFunction
+
+  t.deepEqual(results.segments, [
+    utils.partialSegment('{var}-{var}-{var}', ['day', 'month', 'year'], matchFunction)
+  ], 'has one partial segment with three variables')
+
+  t.ok(rhumb._parse('/{day}-{month}-{year}').leadingSlash, 'has a leading slash')
+  t.notOk(rhumb._parse('/{day}-{month}-{year}').trailingSlash, 'has no trailing slash')
+
+  t.deepEqual(matchFunction('07.03.2017'), null, 'when partial is not match no results are returned')
+  t.deepEqual(matchFunction('-03-2017'), null, 'when empty partial match no results are returned')
+  t.deepEqual(matchFunction('07-03-2017'), { day: '07', month: '03', year: '2017' }, 'match function find values of all variables')
 })

--- a/test/parsing/variable-paths.test.js
+++ b/test/parsing/variable-paths.test.js
@@ -1,41 +1,12 @@
 var test  = require('tape')
   , rhumb = require('../../src/rhumb')
+  , utils = require('../utils')
 
-var root = { type: 'fixed', input: '/' }
+test('Parsing should find segments for a path with variable segments', function (t) {
+  t.plan(4)
 
-test("Parsing should find single variable part", function(t) {
-  var out = rhumb._parse("/{wibble}")
-
-  t.plan(2)
-  t.ok(out)
-  t.deepEqual(out,
-    [ root, { type: "var", input: "wibble" } ]
-  )
-})
-
-test("Parsing should find multiple variable parts", function(t) {
-  var out = rhumb._parse("/{wibble}/{wobble}")
-
-  t.plan(2)
-  t.ok(out)
-  t.deepEqual(out,
-    [ root
-    , { type: "var", input: "wibble" }
-    , { type: "var", input: "wobble" }
-    ]
-  )
-})
-
-test("Parsing should find variable and fixed parts", function(t) {
-  var out = rhumb._parse("/{wibble}/bar/{wobble}")
-
-  t.plan(2)
-  t.ok(out)
-  t.deepEqual(out,
-    [ root
-    , { type: "var", input: "wibble" }
-    , { type: "fixed", input: "bar" }
-    , { type: "var", input: "wobble" }
-    ]
-  )
+  t.deepEqual(rhumb._parse('/{foo}').segments, [utils.varSegment('foo')], 'one variable segment found')
+  t.deepEqual(rhumb._parse('/wibble/{foo}').segments, [utils.fixedSegment('wibble'), utils.varSegment('foo')], 'one fixed and one variable segment found')
+  t.deepEqual(rhumb._parse('/{foo}/wobble').segments, [utils.varSegment('foo'), utils.fixedSegment('wobble')], 'one fixed and one variable segment found')
+  t.deepEqual(rhumb._parse('/{foo}/{bar}').segments, [utils.varSegment('foo'), utils.varSegment('bar')], 'two variable segments found')
 })

--- a/test/routing/ambiguity.test.js
+++ b/test/routing/ambiguity.test.js
@@ -1,113 +1,135 @@
-var test  = require('tape')
+var test = require('tape')
   , rhumb = require('../../src/rhumb')
 
-test('Routing should detect /foo and (/foo) as ambiguous', function(t) {
+test('Routing should detect / and (/) as ambiguous', function (t) {
   t.plan(1)
   var router = rhumb.create()
 
-  router.add('/foo', function() {})
+  router.add('/', function () {})
 
-  t.throws(function() {
-    router.add('(/foo)', function() {})
+  t.throws(function () {
+    router.add('/', function () {})
   })
 })
 
-test('Routing should detect /foo and /foo as ambiguous', function(t) {
+test('Routing should detect /foo and (/foo) as ambiguous', function (t) {
   t.plan(1)
   var router = rhumb.create()
 
-  router.add('/foo', function() {})
+  router.add('/foo', function () {})
 
-  t.throws(function() {
-    router.add('/foo', function() {})
+  t.throws(function () {
+    router.add('(/foo)', function () {})
   })
 })
 
-test("Routing should detect /foo/{bar} and /foo/{maybe} as ambiguous", function(t) {
+test('Routing should detect /foo and /foo as ambiguous', function (t) {
   t.plan(1)
   var router = rhumb.create()
 
-  router.add("/foo/{bar}", function() {})
+  router.add('/foo', function () {})
 
-  t.throws(function() {
-    router.add("/foo/{maybe}", function() {})
+  t.throws(function () {
+    router.add('/foo', function () {})
   })
 })
 
-test("Routing should detect /foo/{bar} and /foo(/{maybe}) as ambiguous", function(t) {
+test('Routing should detect /foo/{bar} and /foo/{maybe} as ambiguous', function (t) {
   t.plan(1)
   var router = rhumb.create()
 
-  router.add("/foo/{bar}", function() {})
+  router.add('/foo/{bar}', function () {})
 
-  t.throws(function() {
-    router.add("/foo(/{maybe})", function() {})
+  t.throws(function () {
+    router.add('/foo/{maybe}', function () {})
   })
 })
 
-test("Routing should detect /foo/{bar} and /foo/{maybe} as ambiguous", function(t) {
+test('Routing should detect /foo/{bar} and /foo(/{maybe}) as ambiguous', function (t) {
   t.plan(1)
   var router = rhumb.create()
 
-  router.add("/foo(/{bar})", function() {})
+  router.add('/foo/{bar}', function () {})
 
-  t.throws(function() {
-    router.add("/foo/{maybe}", function() {})
+  t.throws(function () {
+    router.add('/foo(/{maybe})', function () {})
   })
 })
 
-test("Routing should detect /foo(/{bar}) and /foo(/{maybe}) as ambiguous", function(t) {
+test('Routing should detect /foo/{bar} and /foo/{maybe} as ambiguous', function (t) {
   t.plan(1)
   var router = rhumb.create()
 
-  router.add("/foo(/{bar})", function() {})
+  router.add('/foo(/{bar})', function () {})
 
-  t.throws(function() {
-    router.add("/foo(/{maybe})", function() {})
+  t.throws(function () {
+    router.add('/foo/{maybe}', function () {})
+  })
+})
+
+test('Routing should detect /foo(/{bar}) and /foo(/{maybe}) as ambiguous', function (t) {
+  t.plan(1)
+  var router = rhumb.create()
+
+  router.add('/foo(/{bar})', function () {})
+
+  t.throws(function () {
+    router.add('/foo(/{maybe})', function () {})
   })
 })
 
 
-test("Routing should detect /foo/moo{bar} and /foo/moo{maybe} as ambiguous", function(t) {
+test('Routing should detect /foo/moo{bar} and /foo/moo{maybe} as ambiguous', function (t) {
   t.plan(1)
   var router = rhumb.create()
 
-  router.add("/foo/moo{bar}", function() {})
+  router.add('/foo/moo{bar}', function () {})
 
-  t.throws(function() {
-    router.add("/foo/moo{maybe}", function() {})
+  t.throws(function () {
+    router.add('/foo/moo{maybe}', function () {})
   })
 })
 
-test("Routing should detect /foo/moo{bar} and /foo(/moo{maybe}) as ambiguous", function(t) {
+test('Routing should detect /foo/moo{bar} and /foo(/moo{maybe}) as ambiguous', function (t) {
   t.plan(1)
   var router = rhumb.create()
 
-  router.add("/foo/moo{bar}", function() {})
+  router.add('/foo/moo{bar}', function () {})
 
-  t.throws(function() {
-    router.add("/foo(/moo{maybe})", function() {})
+  t.throws(function () {
+    router.add('/foo(/moo{maybe})', function () {})
   })
 })
 
-test("Routing should detect /foo/moo{bar} and /foo/moo{maybe} as ambiguous", function(t) {
+test('Routing should detect /foo/moo{bar} and /foo/moo{maybe} as ambiguous', function (t) {
   t.plan(1)
   var router = rhumb.create()
 
-  router.add("/foo(/moo{bar})", function() {})
+  router.add('/foo(/moo{bar})', function () {})
 
-  t.throws(function() {
-    router.add("/foo/moo{maybe}", function() {})
+  t.throws(function () {
+    router.add('/foo/moo{maybe}', function () {})
   })
 })
 
-test("Routing should detect /foo(/moo{bar}) and /foo(/moo{maybe}) as ambiguous", function(t) {
+test('Routing should detect /foo(/moo{bar}) and /foo(/moo{maybe}) as ambiguous', function (t) {
   t.plan(1)
   var router = rhumb.create()
 
-  router.add("/foo(/moo{bar})", function() {})
+  router.add('/foo(/moo{bar})', function () {})
 
-  t.throws(function() {
-    router.add("/foo(/moo{maybe})", function() {})
+  t.throws(function () {
+    router.add('/foo(/moo{maybe})', function () {})
+  })
+})
+
+test('Routing should detect /foo(/abc) and /foo(/def) as ambiguous', function (t) {
+  t.plan(1)
+  var router = rhumb.create()
+
+  router.add('/foo(/abc)', function () {})
+
+  t.throws(function () {
+    router.add('/foo(/def)', function () {})
   })
 })

--- a/test/routing/empty-segments.test.js
+++ b/test/routing/empty-segments.test.js
@@ -1,0 +1,24 @@
+var test = require('tape')
+  , rhumb = require('../../src/rhumb')
+  , emptySegmentRouteError = /Invalid route: Must not contain an empty segment/
+
+test('Routing should throw an error for adding routes with empty segments', function (t) {
+  t.plan(4)
+  var router = rhumb.create()
+
+  t.throws(function () {
+    router.add('//', function () {})
+  }, emptySegmentRouteError)
+
+  t.throws(function () {
+    router.add('//bar/bing', function () {})
+  }, emptySegmentRouteError)
+
+  t.throws(function () {
+    router.add('/foo//bing', function () {})
+  }, emptySegmentRouteError)
+
+  t.throws(function () {
+    router.add('/foo/bar//', function () {})
+  }, emptySegmentRouteError)
+})

--- a/test/routing/empty-segments.test.js
+++ b/test/routing/empty-segments.test.js
@@ -1,6 +1,7 @@
 var test = require('tape')
   , rhumb = require('../../src/rhumb')
   , emptySegmentRouteError = /Invalid route: Must not contain an empty segment/
+  , emptySegmentPathError = /Invalid path: Must not contain an empty segment/
 
 test('Routing should throw an error for adding routes with empty segments', function (t) {
   t.plan(4)
@@ -21,4 +22,28 @@ test('Routing should throw an error for adding routes with empty segments', func
   t.throws(function () {
     router.add('/foo/bar//', function () {})
   }, emptySegmentRouteError)
+})
+
+test('Routing should throw an error for matching paths with empty segments', function (t) {
+  t.plan(4)
+  var router = rhumb.create()
+
+  router.add('/{foo}', function () {})
+  router.add('/{foo}/{bar}/{bing}', function () {})
+
+  t.throws(function () {
+    router.match('//')
+  }, emptySegmentPathError)
+
+  t.throws(function () {
+    router.match('//bar/bing')
+  }, emptySegmentPathError)
+
+  t.throws(function () {
+    router.match('/foo//bing')
+  }, emptySegmentPathError)
+
+  t.throws(function () {
+    router.match('/foo/bar//')
+  }, emptySegmentPathError)
 })

--- a/test/routing/optional-paths.test.js
+++ b/test/routing/optional-paths.test.js
@@ -1,5 +1,6 @@
 var test  = require('tape')
   , rhumb = require('../../src/rhumb')
+  , optionalPathError = /Invalid path: Must not contain an optional path/
 
 test("Routing should match /foo(/bar) with /foo and /foo/bar", function(t) {
   t.plan(2)
@@ -27,4 +28,23 @@ test("Routing should match /foo(/{bar}(/{bay})) with /foo, /foo/knew & /foo/knew
   router.match("/foo")
   router.match("/foo/knew")
   router.match("/foo/knew/you")
+})
+
+test('Routing should throw an error for matching paths with optional parts', function (t) {
+  t.plan(3)
+  var router = rhumb.create()
+
+  router.add('/foo(/bar(/bing))', function () {})
+
+  t.throws(function () {
+    router.match('/foo(/bar)')
+  }, optionalPathError)
+
+  t.throws(function () {
+    router.match('/foo(/bar/bing)')
+  }, optionalPathError)
+
+  t.throws(function () {
+    router.match('/foo/bar(/bing)')
+  }, optionalPathError)
 })

--- a/test/routing/partially-variable-paths.test.js
+++ b/test/routing/partially-variable-paths.test.js
@@ -1,5 +1,6 @@
 var test  = require('tape')
   , rhumb = require('../../src/rhumb')
+  , partialVariableSegmentPathError = /Invalid path: Must not contain a partial variable segment/
 
 test("Routing should match /page-{num} with path /page-four", function(t) {
   t.plan(1)
@@ -56,4 +57,24 @@ test("Routing should match /{day}-{month}-{year} with path /mon-01-2020", functi
   })
 
   router.match("mon-01-2020")
+})
+
+test('Routing should throw an error for matching paths with partial variable segments', function (t) {
+  t.plan(3)
+  var router = rhumb.create()
+
+  router.add('/{foo}-part', function () {})
+  router.add('/part-{foo}/{bar}-part', function () {})
+
+  t.throws(function () {
+    router.match('/{foo}-part')
+  }, partialVariableSegmentPathError)
+
+  t.throws(function () {
+    router.match('/part-{foo}/bing-part')
+  }, partialVariableSegmentPathError)
+
+  t.throws(function () {
+    router.match('/part-foo/{bar}-part')
+  }, partialVariableSegmentPathError)
 })

--- a/test/routing/query-params.test.js
+++ b/test/routing/query-params.test.js
@@ -1,5 +1,6 @@
 var test  = require('tape')
   , rhumb = require('../../src/rhumb')
+  , queryStringInRouteError = /Invalid route: Must not contain a query string/
 
 test("Routing should pass query string params to callback", function(t) {
   var router = rhumb.create()
@@ -69,4 +70,29 @@ test("Routing should not overwrite path params with query params", function(t) {
   })
 
   router.match("/sing/bird-song?sound=bark")
+})
+
+test('Routing should throw an error when adding a route with a query string', function (t) {
+  t.plan(5)
+  var router = rhumb.create()
+
+  t.throws(function () {
+    router.add('/sing?foo=bar&baz=bam')
+  }, queryStringInRouteError)
+
+  t.throws(function () {
+    router.add('/sing/bird-song?foo=bar&baz=bam')
+  }, queryStringInRouteError)
+
+  t.throws(function () {
+    router.add('/sing/bird-song?foo=&bar&baz=bop')
+  }, queryStringInRouteError)
+
+  t.throws(function () {
+    router.add('/sing?foo=&')
+  }, queryStringInRouteError)
+
+  t.throws(function () {
+    router.add('/sing/bird-song?sound=bark')
+  }, queryStringInRouteError)
 })

--- a/test/routing/variable-paths.test.js
+++ b/test/routing/variable-paths.test.js
@@ -1,5 +1,6 @@
 var test  = require('tape')
   , rhumb = require('../../src/rhumb')
+  , variableSegmentPathError = /Invalid path: Must not contain a variable segment/
 
 test("Routing should match /{foo} with path /bar", function(t) {
   t.plan(1)
@@ -52,4 +53,24 @@ test("Routing should match /foo/{bar} and /foo/{bar}/{baz} as different paths", 
 
   router.match("/foo/one")
   router.match("/foo/two/three")
+})
+
+test('Routing should throw an error for matching paths with variable segments', function (t) {
+  t.plan(3)
+  var router = rhumb.create()
+
+  router.add('/{foo}', function () {})
+  router.add('/{foo}/{bar}', function () {})
+
+  t.throws(function () {
+    router.match('/{foo}')
+  }, variableSegmentPathError)
+
+  t.throws(function () {
+    router.match('/{foo}/bing')
+  }, variableSegmentPathError)
+
+  t.throws(function () {
+    router.match('/foo/{bar}')
+  }, variableSegmentPathError)
 })

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,31 @@
+function emptySegment() {
+  return { type: 'empty' }
+}
+
+function fixedSegment(identifier) {
+  return { type: 'fixed', identifier: identifier }
+}
+
+function partialSegment(identifier, vars, matchFunction) {
+  return { type: 'partial', identifier: identifier, vars: vars, matchFunction: matchFunction }
+}
+
+function varSegment(identifier) {
+  return { type: 'var', identifier: identifier }
+}
+
+function optionalPart(segments, leadingSlash, trailingSlash) {
+  return {
+    segments: segments
+  , leadingSlash: !!leadingSlash
+  , trailingSlash: !!trailingSlash
+  }
+}
+
+module.exports = {
+  emptySegment: emptySegment
+, fixedSegment: fixedSegment
+, optionalPart: optionalPart
+, partialSegment: partialSegment
+, varSegment: varSegment
+}


### PR DESCRIPTION
In order to perform interpolation, we should be able to parse a path whilst keeping track of empty segments and detect leading or trailing slashes.  Rather than doing this work in _<https://github.com/websdk/rhumb/pull/18>_, it seemed better to pull this work out to here.

This is going to involve some big changes to how parse works.  I have updated the unit tests for parse (as the output is formatted differently, however I have only added tests to the routing code.

Also this allows us to review the parsing as a whole and explore how the edge cases are handled.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change follows the style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
