### PR TITLE
Trailing slashes should be inherited from optional parts

### DIFF
--- a/src/rhumb.js
+++ b/src/rhumb.js
@@ -290,6 +290,7 @@ function parseOptional(ptn) {
     var optionalSegment = parseOptional(ptn.substr(i))
     if (optionalSegment.segments.length > 0) {
       parsedOutput.segments.push(optionalSegment)
+      parsedOutput.trailingSlash = optionalSegment.trailingSlash
     }
   }
 

--- a/test/parsing/optional-paths.test.js
+++ b/test/parsing/optional-paths.test.js
@@ -149,3 +149,73 @@ test('Parsing should handle a path with empty optional part', function (t) {
     utils.fixedSegment('wibble()')
   ], 'ignores empty optional path when being parsed')
 })
+
+test('Parsing should identify whether a path has a trailing slash based upon the optional elements at end of path', function (t) {
+  t.plan(24)
+  var hasTrailingSlash = function (path) {
+        var result = rhumb._parse(path)
+          , lastOptionalPath = result.segments.slice(-1)[0]
+
+        t.ok(lastOptionalPath.trailingSlash, 'last optional path has a trailing slash')
+        t.ok(result.trailingSlash, 'top level path inherits the trailing slash')
+      }
+    , hasNoTrailingSlash = function (path) {
+        var result = rhumb._parse(path)
+          , lastOptionalPath = result.segments.slice(-1)[0]
+
+        t.notOk(lastOptionalPath.trailingSlash, 'last optional path has no trailing slash')
+        t.notOk(result.trailingSlash, 'top level path inherits no trailing slash')
+      }
+
+  hasNoTrailingSlash('/foo(/bar)')
+  hasNoTrailingSlash('/foo(/bar/bing)')
+  hasNoTrailingSlash('foo(/bar)')
+  hasNoTrailingSlash('foo(/bar/bing)')
+
+  hasTrailingSlash('/foo(/bar/)')
+  hasTrailingSlash('/foo(/bar/bing/)')
+  hasTrailingSlash('foo(/bar/)')
+  hasTrailingSlash('foo(/bar/bing/)')
+
+  hasTrailingSlash('/foo(//)')
+  hasNoTrailingSlash('/foo(//bar/bing)')
+  hasNoTrailingSlash('foo(/bar//bing)')
+  hasTrailingSlash('foo(/bar//)')
+})
+
+test('Parsing should identify whether a path has a trailing slash based upon the nested optional elements at end of path', function (t) {
+  t.plan(36)
+  var hasTrailingSlash = function (path) {
+        var result = rhumb._parse(path)
+          , lastOptionalPath = result.segments.slice(-1)[0]
+          , lastNestedOptionalPath = lastOptionalPath.segments.slice(-1)[0]
+
+        t.ok(lastNestedOptionalPath.trailingSlash, 'last nested optional path has a trailing slash')
+        t.ok(lastOptionalPath.trailingSlash, 'last optional path inherits the trailing slash')
+        t.ok(result.trailingSlash, 'top level path inherits the trailing slash')
+      }
+    , hasNoTrailingSlash = function (path) {
+        var result = rhumb._parse(path)
+          , lastOptionalPath = result.segments.slice(-1)[0]
+          , lastNestedOptionalPath = lastOptionalPath.segments.slice(-1)[0]
+
+        t.notOk(lastNestedOptionalPath.trailingSlash, 'last nested optional path has no trailing slash')
+        t.notOk(lastOptionalPath.trailingSlash, 'last optional path has no trailing slash')
+        t.notOk(result.trailingSlash, 'top level path has no trailing slash')
+      }
+
+  hasNoTrailingSlash('/foo(/bar(/bing))')
+  hasNoTrailingSlash('/foo(/bar(/bing/zap))')
+  hasNoTrailingSlash('foo(/bar(/bing))')
+  hasNoTrailingSlash('foo(/bar(/bing/zap))')
+
+  hasTrailingSlash('/foo(/bar(/bing/))')
+  hasTrailingSlash('/foo(/bar(/bing/zap/))')
+  hasTrailingSlash('foo(/bar(/bing/))')
+  hasTrailingSlash('foo(/bar(/bing/zap/))')
+
+  hasTrailingSlash('/foo(/bar(//))')
+  hasNoTrailingSlash('/foo(/bar(//bing))')
+  hasNoTrailingSlash('foo(/bar(/bing//zap))')
+  hasTrailingSlash('foo(/bar(/bing//))')
+})


### PR DESCRIPTION
Currently trailing slashes should be inherited from optional parts.

I would expect that the _ALL_ following assertions would be true, but they are not:

```javascript
  hasNoTrailingSlash('/foo(/bar/bing)') // Already passes
  hasTrailingSlash('/foo(/bar/bing/)') // Fails
  hasTrailingSlash('foo(/bar//)') // Fails

  hasNoTrailingSlash('/foo(/bar(/bing/zap))') // Already passes
  hasTrailingSlash('/foo(/bar(/bing/zap/))') // Fails
  hasTrailingSlash('foo(/bar(/bing//))') // Fails
```

## Motivation and Context

This is needed as `interpolate()` is being developed and that uses the trailing slash information.  I think the inheritance should be specified in the parser, rather than in the interpolate logic.

## How Was This Tested?
:writing_hand: Unit tests created.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change follows the style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
