### PR TITLE
introduce interpolation functionality to project

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Rhumb allows you to take a route and a set of params and produce a path that can
 
 #### fixed paths
 
-When you give `.interpolate(...)` a route without any declared variables or partial variable parts, then you will not see much changes:
+When you give `.interpolate(...)` a route without any declared variables or partial variable parts, then a valid path will be returned and you will typically not see any changes:
 
 ```javascript
 rhumb.interpolate("/stories", {})
@@ -146,10 +146,21 @@ rhumb.interpolate("/stories?sortBy=publishedDate", {})
 // returns "/stories?sortBy=publishedDate"
 ```
 
+When the route you supplied is not a valid path, Rhumb will step in and escape some of the characters, so that a valid path can be produced.
+
+If your route has empty parts, then some of the slash characters will be encoded to `%2F`:
+
+```javascript
+rhumb.interpolate('//sarah/scary', {})
+// returns "/%2Fsarah/scary"
+
+rhumb.interpolate('stories//scary', {})
+// returns "stories%2F/scary"
+```
 
 #### variable parts
 
-When variables are present, Rhumb is will interpolate the variables with the params you supply:
+When variables are present, Rhumb will interpolate the variables with the params you supply:
 
 ```javascript
 rhumb.interpolate("/potatoes/{variety}", { variety: "marabel" })
@@ -159,7 +170,7 @@ rhumb.interpolate("/shoes/{color}/{size}", { color: "red", size: "6" })
 // returns "/shoes/red/6"
 ```
 
-For interpolation to produce a valid path, it will throw and error when a required variable is absent, `""`, `null` or `undefined`:
+For interpolation to produce a valid path, it will throw an error when a required variable is absent, `""`, `null` or `undefined`:
 
 ```javascript
 rhumb.interpolate("/potatoes/{variety}", {})
@@ -183,7 +194,7 @@ rhumb.interpolate("/author/{forename}-{surname}", { forename: "susan", surname: 
 // returns "/author/susan-smith"
 ```
 
-It will also throw and error when a required partial variable is absent, `""`, `null` or `undefined`:
+It will also throw an error when a required partial variable is absent, `""`, `null` or `undefined`:
 
 ```javascript
 rhumb.interpolate("/orders/{days}-days-ago", { days: "" })
@@ -197,7 +208,7 @@ To mark a partially variable part as not-required, it has to be wrapped in an op
 
 #### optional parts
 
-Rhumb has is greedy with how it handles optional paths when interpolating, so expect optional parts to be included whenever possible.
+Rhumb is greedy with how it handles optional paths when interpolating, so expect optional parts to be included whenever possible.
 
 ```javascript
 rhumb.interpolate("/stories(/bob)", {})
@@ -207,7 +218,7 @@ rhumb.interpolate("/stories(/sarah(/scary))", {})
 // returns "/stories/sarah/scary"
 ```
 
-When variables or partially variables in optional parts are absent, `""`, `null` or `undefined` then no error is thown and the optional part is dropped.
+When variables or partially variables in optional parts are absent, `""`, `null` or `undefined` then no error is thrown and the optional part is dropped.
 
 ```javascript
 rhumb.interpolate("/stories(/by-{name})", {})

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Bells and Whistles
 * partially variable parts
 * optional parts
 * parameter parsing
+* interpolate params to produce paths
 
 
 Basic Usage
@@ -41,6 +42,12 @@ Whatever you return in the callback will to handed back to the caller of `match`
 
 ```javascript
 redShoes = rhumb.match("/happy/shoes/red")
+```
+
+When you need to create a URI from a set of params, the `interpolate` function can be used
+
+```javascript
+redShoesUri = rhumb.interpolate("/happy/shoes/{color}", { color: "red" })
 ```
 
 Route Syntax
@@ -121,6 +128,94 @@ Will match
 * `/stories/sarah/scary`
 
 Have fun!
+
+Parameter Interpolation
+-----------------------
+
+Rhumb allows you to take a route and a set of params and produce a path that can be matched against a route.
+
+#### fixed paths
+
+When you give `.interpolate(...)` a route without any declared variables or partial variable parts, then you will not see much changes:
+
+```javascript
+rhumb.interpolate("/stories", {})
+// returns "/stories"
+
+rhumb.interpolate("/stories?sortBy=publishedDate", {})
+// returns "/stories?sortBy=publishedDate"
+```
+
+
+#### variable parts
+
+When variables are present, Rhumb is will interpolate the variables with the params you supply:
+
+```javascript
+rhumb.interpolate("/potatoes/{variety}", { variety: "marabel" })
+// returns "/potatoes/marabel"
+
+rhumb.interpolate("/shoes/{color}/{size}", { color: "red", size: "6" })
+// returns "/shoes/red/6"
+```
+
+For interpolation to produce a valid path, it will throw and error when a required variable is absent, `""`, `null` or `undefined`:
+
+```javascript
+rhumb.interpolate("/potatoes/{variety}", {})
+// throws 'Invalid parameter: "variety" is missing'
+
+rhumb.interpolate("/shoes/{color}/{size}", { color: "red", size: null })
+// throws 'Invalid parameter: "size" is null'
+```
+
+To mark a variable part as not-required, it has to be wrapped in an optional path, as shown later.
+
+#### partially variable parts
+
+Like variables, Rhumb will interpolate partially variable parts when they are defined and not empty in the supplied params:
+
+```javascript
+rhumb.interpolate("/orders/{days}-days-ago", { days: "40" })
+// returns "/orders/40-days-ago"
+
+rhumb.interpolate("/author/{forename}-{surname}", { forename: "susan", surname: "smith" })
+// returns "/author/susan-smith"
+```
+
+It will also throw and error when a required partial variable is absent, `""`, `null` or `undefined`:
+
+```javascript
+rhumb.interpolate("/orders/{days}-days-ago", { days: "" })
+// throws 'Invalid parameter: "days" is empty'
+
+rhumb.interpolate("/author/{forename}-{surname}", { forename: "susan", surname: undefined })
+// throws 'Invalid parameter: "surname" is undefined'
+```
+
+To mark a partially variable part as not-required, it has to be wrapped in an optional path, as shown later.
+
+#### optional parts
+
+Rhumb has is greedy with how it handles optional paths when interpolating, so expect optional parts to be included whenever possible.
+
+```javascript
+rhumb.interpolate("/stories(/bob)", {})
+// returns "/stories/bob"
+
+rhumb.interpolate("/stories(/sarah(/scary))", {})
+// returns "/stories/sarah/scary"
+```
+
+When variables or partially variables in optional parts are absent, `""`, `null` or `undefined` then no error is thown and the optional part is dropped.
+
+```javascript
+rhumb.interpolate("/stories(/by-{name})", {})
+// returns "/stories"
+
+rhumb.interpolate("/stories(/{author}(/{genre}))", { author: "sarah", genre: "" })
+// returns "/stories/sarah"
+```
 
 Found an issue, or want to contribute?
 --------------------------------------

--- a/src/rhumb.js
+++ b/src/rhumb.js
@@ -327,7 +327,7 @@ function tryReadingParamValue(params, key) {
 }
 
 function joinPaths(path, item) {
-  var pathStartingWithSlashes = /^\/(%2F)+$/
+  var pathStartingWithSlashes = /^\/?(%2F)+$/
   if (path === '' || path.match(pathStartingWithSlashes) || path[path.length - 1] === '/') {
     return path + item
   }

--- a/src/rhumb.js
+++ b/src/rhumb.js
@@ -304,11 +304,114 @@ function parse(route) {
         : parsePtn(split[0])
 
   parsedPath.queryParams = parseQueryString(split[1])
+  parsedPath.queryParamsString = split[1] ? '?' + split[1] : null
   return parsedPath
+}
+
+function tryReadingParamValue(params, key) {
+  if (!(key in params)) {
+    throw new Error('Invalid parameter: "' + key + '" is not supplied')
+  }
+
+  var value = params[key]
+  switch (value) {
+    case '':
+      throw new Error('Invalid parameter: "' + key + '" is an empty value')
+    case undefined:
+      throw new Error('Invalid parameter: "' + key + '" is undefined')
+    case null:
+      throw new Error('Invalid parameter: "' + key + '" is null')
+    default:
+      return value
+  }
+}
+
+function joinPaths(path, item) {
+  var pathStartingWithSlashes = /^\/(%2F)+$/
+  if (path === '' || path.match(pathStartingWithSlashes) || path[path.length - 1] === '/') {
+    return path + item
+  }
+  return path + '/' + item
+}
+
+function interpolateEmpty(path) {
+  return path + '%2F'
+}
+
+function interpolateVar(path, segment, params) {
+  var value = tryReadingParamValue(params, segment.identifier)
+  return joinPaths(path, value)
+}
+
+function interpolateFixed(path, segment) {
+  return joinPaths(path, segment.identifier)
+}
+
+function interpolatePartial(path, segment, params) {
+  var i = 0
+    , match = segment.identifier.replace(/\{var\}/g, function () {
+        var varName = segment.vars[i++]
+          , value = tryReadingParamValue(params, varName)
+        return value
+      })
+
+  return joinPaths(path, match)
+}
+
+function interpolateOptional(path, optionalSegment, params) {
+  try {
+    return joinPaths(path, optionalSegment.segments.reduce(
+      function (optionalPath, segment) {
+        switch (segment.type) {
+          case 'empty':
+            return interpolateEmpty(optionalPath)
+          case 'var':
+            return interpolateVar(optionalPath, segment, params)
+          case 'partial':
+            return interpolatePartial(optionalPath, segment, params)
+          case 'fixed':
+            return interpolateFixed(optionalPath, segment)
+          default:
+            return optionalPath ? interpolateOptional(optionalPath, segment, params) : ''
+        }
+      }, ''))
+  } catch (ex) {
+    return path
+  }
+}
+
+function interpolate(route, params) {
+  var parsedRoute = parse(route)
+    , queryParamsString = parsedRoute.queryParamsString
+    , interpolatedPath = parsedRoute.segments.reduce(function (path, segment) {
+        switch (segment.type) {
+          case 'empty':
+            return interpolateEmpty(path)
+          case 'var':
+            return interpolateVar(path, segment, params)
+          case 'partial':
+            return interpolatePartial(path, segment, params)
+          case 'fixed':
+            return interpolateFixed(path, segment)
+          default:
+            return interpolateOptional(path, segment, params)
+        }
+    }, parsedRoute.leadingSlash ? '/' : '')
+
+    if (parsedRoute.trailingSlash) {
+      interpolatedPath = joinPaths(interpolatedPath, '')
+    }
+
+    if (parsedRoute.queryParamsString) {
+      interpolatedPath += queryParamsString
+    }
+
+  return interpolatedPath
 }
 
 var rhumb = create()
 rhumb.create = create
+rhumb.interpolate = interpolate
 rhumb._parse = parse
 rhumb._findInTree = findIn
 

--- a/test/interpolating/empty-paths.test.js
+++ b/test/interpolating/empty-paths.test.js
@@ -1,0 +1,20 @@
+var test = require('tape')
+  , rhumb = require('../../src/rhumb')
+
+test('Interpolating should handle empty paths', function (t) {
+  t.plan(2)
+
+  t.equal(rhumb.interpolate('/', {}), '/'
+    , 'keeps leading slash when provided')
+  t.equal(rhumb.interpolate('', {}), ''
+    , 'keeps path unmodified when no leading slash')
+})
+
+test('Interpolating should handle empty paths with query params', function (t) {
+  t.plan(2)
+
+  t.equal(rhumb.interpolate('/?q=value', {}), '/?q=value'
+    , 'keeps leading slash when provided')
+  t.equal(rhumb.interpolate('?q=value', {}), '?q=value'
+    , 'keeps path unmodified when no leading slash')
+})

--- a/test/interpolating/fixed-paths.test.js
+++ b/test/interpolating/fixed-paths.test.js
@@ -88,6 +88,33 @@ test('Interpolating should handle slashes before the optional paths', function (
     , 'prevent double slashes from occuring')
 })
 
+test('Interpolating should handle multi-segment fixed optional paths', function (t) {
+  t.plan(10)
+
+  t.equal(rhumb.interpolate('/wibble(//foo/bar)', {}), '/wibble/%2Ffoo/bar'
+    , 'keeps leading slash when provided')
+  t.equal(rhumb.interpolate('wibble(//foo/bar)', {}), 'wibble/%2Ffoo/bar'
+    , 'keeps path unmodified when no leading slash')
+  t.equal(rhumb.interpolate('/wibble(//foo/bar/)', {}), '/wibble/%2Ffoo/bar/'
+    , 'keeps leading and trailing slash when provided')
+  t.equal(rhumb.interpolate('wibble(//foo/bar/)', {}), 'wibble/%2Ffoo/bar/'
+    , 'keeps trailing slash when provided')
+
+  t.equal(rhumb.interpolate('/wibble(/foo//bar)', {}), '/wibble/foo%2F/bar'
+    , 'keeps leading slash when provided')
+  t.equal(rhumb.interpolate('wibble(/foo//bar)', {}), 'wibble/foo%2F/bar'
+    , 'keeps path unmodified when no leading slash')
+  t.equal(rhumb.interpolate('/wibble(/foo//bar/)', {}), '/wibble/foo%2F/bar/'
+    , 'keeps leading and trailing slash when provided')
+  t.equal(rhumb.interpolate('wibble(/foo//bar/)', {}), 'wibble/foo%2F/bar/'
+    , 'keeps trailing slash when provided')
+
+  t.equal(rhumb.interpolate('/wibble(/foo/bar//)', {}), '/wibble/foo/bar%2F/'
+    , 'keeps leading and trailing slash when provided')
+  t.equal(rhumb.interpolate('wibble(/foo/bar//)', {}), 'wibble/foo/bar%2F/'
+    , 'keeps trailing slash when provided')
+})
+
 test('Interpolating should handle empty segments in fixed paths', function (t) {
   t.plan(8)
 

--- a/test/interpolating/fixed-paths.test.js
+++ b/test/interpolating/fixed-paths.test.js
@@ -1,0 +1,155 @@
+var test = require('tape')
+  , rhumb = require('../../src/rhumb')
+
+test('Interpolating should handle single segment fixed paths', function (t) {
+  t.plan(4)
+
+  t.equal(rhumb.interpolate('/foo', {}), '/foo'
+    , 'keeps leading slash when provided')
+  t.equal(rhumb.interpolate('foo', {}), 'foo'
+    , 'keeps path unmodified when no leading slash')
+  t.equal(rhumb.interpolate('/foo/', {}), '/foo/'
+    , 'keeps leading and trailing slash when provided')
+  t.equal(rhumb.interpolate('foo/', {}), 'foo/'
+    , 'keeps trailing slash when provided')
+})
+
+test('Interpolating should handle multi-segment fixed paths', function (t) {
+  t.plan(4)
+
+  t.equal(rhumb.interpolate('/foo/bar/bing', {}), '/foo/bar/bing'
+    , 'keeps leading slash when provided')
+  t.equal(rhumb.interpolate('foo/bar/bing', {}), 'foo/bar/bing'
+    , 'keeps path unmodified when no leading slash')
+  t.equal(rhumb.interpolate('/foo/bar/bing/', {}), '/foo/bar/bing/'
+    , 'keeps leading and trailing slash when provided')
+  t.equal(rhumb.interpolate('foo/bar/bing/', {}), 'foo/bar/bing/'
+    , 'keeps trailing slash when provided')
+})
+
+test('Interpolating should handle single segment fixed optional paths', function (t) {
+  t.plan(4)
+
+  t.equal(rhumb.interpolate('/wibble(/foo)', {}), '/wibble/foo'
+    , 'keeps leading slash when provided')
+  t.equal(rhumb.interpolate('wibble(/foo)', {}), 'wibble/foo'
+    , 'keeps path unmodified when no leading slash')
+  t.equal(rhumb.interpolate('/wibble(/foo/)', {}), '/wibble/foo/'
+    , 'keeps leading and trailing slash when provided')
+  t.equal(rhumb.interpolate('wibble(/foo/)', {}), 'wibble/foo/'
+    , 'keeps trailing slash when provided')
+})
+
+test('Interpolating should handle multi-segment fixed optional paths', function (t) {
+  t.plan(4)
+
+  t.equal(rhumb.interpolate('/wibble(/foo/bar)', {}), '/wibble/foo/bar'
+    , 'keeps leading slash when provided')
+  t.equal(rhumb.interpolate('wibble(/foo/bar)', {}), 'wibble/foo/bar'
+    , 'keeps path unmodified when no leading slash')
+  t.equal(rhumb.interpolate('/wibble(/foo/bar/)', {}), '/wibble/foo/bar/'
+    , 'keeps leading and trailing slash when provided')
+  t.equal(rhumb.interpolate('wibble(/foo/bar/)', {}), 'wibble/foo/bar/'
+    , 'keeps trailing slash when provided')
+})
+
+test('Interpolating should handle fixed nested optional paths', function (t) {
+  t.plan(4)
+
+  t.equal(rhumb.interpolate('/wibble(/foo(/bar))', {}), '/wibble/foo/bar'
+    , 'keeps leading slash when provided')
+  t.equal(rhumb.interpolate('wibble(/foo(/bar))', {}), 'wibble/foo/bar'
+    , 'keeps path unmodified when no leading slash')
+  t.equal(rhumb.interpolate('/wibble(/foo(/bar/))', {}), '/wibble/foo/bar/'
+    , 'keeps leading and trailing slash when provided')
+  t.equal(rhumb.interpolate('wibble(/foo(/bar/))', {}), 'wibble/foo/bar/'
+    , 'keeps trailing slash when provided')
+})
+
+test('Interpolating should handle slashes before the optional paths', function (t) {
+  t.plan(8)
+
+  t.equal(rhumb.interpolate('/wibble/(/foo)', {}), '/wibble/foo'
+    , 'prevent double slashes from occuring')
+  t.equal(rhumb.interpolate('wibble/(/foo)', {}), 'wibble/foo'
+    , 'prevent double slashes from occuring')
+  t.equal(rhumb.interpolate('/wibble/(/foo/)', {}), '/wibble/foo/'
+    , 'prevent double slashes from occuring')
+  t.equal(rhumb.interpolate('wibble/(/foo/)', {}), 'wibble/foo/'
+    , 'prevent double slashes from occuring')
+
+  t.equal(rhumb.interpolate('/wibble(/foo/(/bar))', {}), '/wibble/foo/bar'
+    , 'prevent double slashes from occuring')
+  t.equal(rhumb.interpolate('wibble(/foo/(/bar))', {}), 'wibble/foo/bar'
+    , 'prevent double slashes from occuring')
+  t.equal(rhumb.interpolate('/wibble(/foo/(/bar/))', {}), '/wibble/foo/bar/'
+    , 'prevent double slashes from occuring')
+  t.equal(rhumb.interpolate('wibble(/foo/(/bar/))', {}), 'wibble/foo/bar/'
+    , 'prevent double slashes from occuring')
+})
+
+test('Interpolating should handle empty segments in fixed paths', function (t) {
+  t.plan(8)
+
+  t.equal(rhumb.interpolate('//', {}), '/%2F'
+    , 'handles just an empty segment')
+  t.equal(rhumb.interpolate('//bar/bing', {}), '/%2Fbar/bing'
+    , 'handles a leading empty segment')
+  t.equal(rhumb.interpolate('/foo//', {}), '/foo%2F/'
+    , 'handles a trailing empty segment')
+  t.equal(rhumb.interpolate('foo//bing', {}), 'foo%2F/bing'
+    , 'handles an empty segment in the middle')
+
+  t.equal(rhumb.interpolate('///', {}), '/%2F%2F'
+    , 'handles just an empty segment')
+  t.equal(rhumb.interpolate('///bar/bing', {}), '/%2F%2Fbar/bing'
+    , 'handles a leading empty segment')
+  t.equal(rhumb.interpolate('/foo///', {}), '/foo%2F%2F/'
+    , 'handles a trailing empty segment')
+  t.equal(rhumb.interpolate('foo///bing', {}), 'foo%2F%2F/bing'
+    , 'handles an empty segment in the middle')
+})
+
+test('Interpolating should handle fixed paths with query params', function (t) {
+  t.plan(8)
+
+  t.equal(rhumb.interpolate('/foo?q=value', {}), '/foo?q=value'
+    , 'keeps leading slash when provided')
+  t.equal(rhumb.interpolate('foo?q=value', {}), 'foo?q=value'
+    , 'keeps path unmodified when no leading slash')
+  t.equal(rhumb.interpolate('/foo/?q=value', {}), '/foo/?q=value'
+    , 'keeps leading and trailing slash when provided')
+  t.equal(rhumb.interpolate('foo/?q=value', {}), 'foo/?q=value'
+    , 'keeps trailing slash when provided')
+
+  t.equal(rhumb.interpolate('/foo/bar/bing?q=value', {}), '/foo/bar/bing?q=value'
+    , 'keeps leading slash when provided')
+  t.equal(rhumb.interpolate('foo/bar/bing?q=value', {}), 'foo/bar/bing?q=value'
+    , 'keeps path unmodified when no leading slash')
+  t.equal(rhumb.interpolate('/foo/bar/bing/?q=value', {}), '/foo/bar/bing/?q=value'
+    , 'keeps leading and trailing slash when provided')
+  t.equal(rhumb.interpolate('foo/bar/bing/?q=value', {}), 'foo/bar/bing/?q=value'
+    , 'keeps trailing slash when provided')
+})
+
+test('Interpolating should handle fixed optional paths with query params', function (t) {
+  t.plan(8)
+
+  t.equal(rhumb.interpolate('/wibble(/foo)?q=value', {}), '/wibble/foo?q=value'
+    , 'keeps leading slash when provided')
+  t.equal(rhumb.interpolate('wibble(/foo)?q=value', {}), 'wibble/foo?q=value'
+    , 'keeps path unmodified when no leading slash')
+  t.equal(rhumb.interpolate('/wibble(/foo/)?q=value', {}), '/wibble/foo/?q=value'
+    , 'keeps leading and trailing slash when provided')
+  t.equal(rhumb.interpolate('wibble(/foo/)?q=value', {}), 'wibble/foo/?q=value'
+    , 'keeps trailing slash when provided')
+
+  t.equal(rhumb.interpolate('/wibble(/foo/bar)?q=value', {}), '/wibble/foo/bar?q=value'
+    , 'keeps leading slash when provided')
+  t.equal(rhumb.interpolate('wibble(/foo/bar)?q=value', {}), 'wibble/foo/bar?q=value'
+    , 'keeps path unmodified when no leading slash')
+  t.equal(rhumb.interpolate('/wibble(/foo/bar/)?q=value', {}), '/wibble/foo/bar/?q=value'
+    , 'keeps leading and trailing slash when provided')
+  t.equal(rhumb.interpolate('wibble(/foo/bar/)?q=value', {}), 'wibble/foo/bar/?q=value'
+    , 'keeps trailing slash when provided')
+})

--- a/test/interpolating/partially-variable-paths.test.js
+++ b/test/interpolating/partially-variable-paths.test.js
@@ -1,0 +1,146 @@
+var test = require('tape')
+  , rhumb = require('../../src/rhumb')
+
+test('Interpolating should handle single non-empty partial variable paths', function (t) {
+  t.plan(4)
+
+  t.equal(rhumb.interpolate('/page-{foo}', { foo: 'bing' }), '/page-bing'
+    , 'interpolates partial variable and keeps leading slash when provided')
+  t.equal(rhumb.interpolate('page-{foo}', { foo: 'bing' }), 'page-bing'
+    , 'interpolates partial variable and keeps path unmodified when no leading slash')
+  t.equal(rhumb.interpolate('/page-{foo}/', { foo: 'bing' }), '/page-bing/'
+    , 'interpolates partial variable and keeps leading and trailing slash when provided')
+  t.equal(rhumb.interpolate('page-{foo}/', { foo: 'bing' }), 'page-bing/'
+    , 'interpolates partial variable and keeps trailing slash when provided')
+})
+
+test('Interpolating should handle paths with a non-empty partial variable segment followed by fixed segment', function (t) {
+  t.plan(4)
+
+  t.equal(rhumb.interpolate('/{foo}.v1/wobble', { foo: 'bing' }), '/bing.v1/wobble'
+    , 'interpolates partial variable and keeps leading slash when provided')
+  t.equal(rhumb.interpolate('{foo}.v1/wobble', { foo: 'bing' }), 'bing.v1/wobble'
+    , 'interpolates partial variable and keeps path unmodified when no leading slash')
+  t.equal(rhumb.interpolate('/{foo}.v1/wobble/', { foo: 'bing' }), '/bing.v1/wobble/'
+    , 'interpolates partial variable and keeps leading and trailing slash when provided')
+  t.equal(rhumb.interpolate('{foo}.v1/wobble/', { foo: 'bing' }), 'bing.v1/wobble/'
+    , 'interpolates partial variable and keeps trailing slash when provided')
+})
+
+test('Interpolating should handle paths with a non-empty partial variable segment preceding a fixed segment', function (t) {
+  t.plan(4)
+
+  t.equal(rhumb.interpolate('/wibble/__{foo}__', { foo: 'bing' }), '/wibble/__bing__'
+    , 'interpolates partial variable and keeps leading slash when provided')
+  t.equal(rhumb.interpolate('wibble/__{foo}__', { foo: 'bing' }), 'wibble/__bing__'
+    , 'interpolates partial variable and keeps path unmodified when no leading slash')
+  t.equal(rhumb.interpolate('/wibble/__{foo}__/', { foo: 'bing' }), '/wibble/__bing__/'
+    , 'interpolates partial variable and keeps leading and trailing slash when provided')
+  t.equal(rhumb.interpolate('wibble/__{foo}__/', { foo: 'bing' }), 'wibble/__bing__/'
+    , 'interpolates partial variable and keeps trailing slash when provided')
+})
+
+test('Interpolating should handle paths with non-empty partial variable segments in optional parts', function (t) {
+  t.plan(4)
+
+  t.equal(rhumb.interpolate('/wibble(/{foo}-part/part-{bar})', { foo: 'bing', bar: 'zap' }), '/wibble/bing-part/part-zap'
+    , 'interpolates partial variable and keeps leading slash when provided')
+  t.equal(rhumb.interpolate('wibble(/{foo}-part/part-{bar})', { foo: 'bing', bar: 'zap' }), 'wibble/bing-part/part-zap'
+    , 'interpolates partial variable and keeps path unmodified when no leading slash')
+  t.equal(rhumb.interpolate('/wibble(/{foo}-part/part-{bar}/)', { foo: 'bing', bar: 'zap' }), '/wibble/bing-part/part-zap/'
+    , 'interpolates partial variable and keeps leading and trailing slash when provided')
+  t.equal(rhumb.interpolate('wibble(/{foo}-part/part-{bar}/)', { foo: 'bing', bar: 'zap' }), 'wibble/bing-part/part-zap/'
+    , 'interpolates partial variable and keeps trailing slash when provided')
+})
+
+test('Interpolating should handle paths with non-empty partial variable segments in nested optional parts', function (t) {
+  t.plan(4)
+
+  t.equal(rhumb.interpolate('/wibble(/{foo}-part(/part-{bar}))', { foo: 'bing', bar: 'zap' }), '/wibble/bing-part/part-zap'
+    , 'interpolates partial variable and keeps leading slash when provided')
+  t.equal(rhumb.interpolate('wibble(/{foo}-part(/part-{bar}))', { foo: 'bing', bar: 'zap' }), 'wibble/bing-part/part-zap'
+    , 'interpolates partial variable and keeps path unmodified when no leading slash')
+  t.equal(rhumb.interpolate('/wibble(/{foo}-part(/part-{bar}/))', { foo: 'bing', bar: 'zap' }), '/wibble/bing-part/part-zap/'
+    , 'interpolates partial variable and keeps leading and trailing slash when provided')
+  t.equal(rhumb.interpolate('wibble(/{foo}-part(/part-{bar}/))', { foo: 'bing', bar: 'zap' }), 'wibble/bing-part/part-zap/'
+    , 'interpolates partial variable and keeps trailing slash when provided')
+})
+
+test('Interpolating should handle single non-empty partial variable paths with query params', function (t) {
+  t.plan(4)
+
+  t.equal(rhumb.interpolate('/page-{foo}?q=value', { foo: 'bing' }), '/page-bing?q=value'
+    , 'interpolates partial variable and keeps leading slash when provided')
+  t.equal(rhumb.interpolate('page-{foo}?q=value', { foo: 'bing' }), 'page-bing?q=value'
+    , 'interpolates partial variable and keeps path unmodified when no leading slash')
+  t.equal(rhumb.interpolate('/page-{foo}/?q=value', { foo: 'bing' }), '/page-bing/?q=value'
+    , 'interpolates partial variable and keeps leading and trailing slash when provided')
+  t.equal(rhumb.interpolate('page-{foo}/?q=value', { foo: 'bing' }), 'page-bing/?q=value'
+    , 'interpolates partial variable and keeps trailing slash when provided')
+})
+
+test('Interpolating should handle paths with non-empty partial variable segments in optional parts with query params', function (t) {
+  t.plan(4)
+
+  t.equal(rhumb.interpolate('/wibble(/{foo}-part/part-{bar})?q=value', { foo: 'bing', bar: 'zap' }), '/wibble/bing-part/part-zap?q=value'
+    , 'interpolates partial variable and keeps leading slash when provided')
+  t.equal(rhumb.interpolate('wibble(/{foo}-part/part-{bar})?q=value', { foo: 'bing', bar: 'zap' }), 'wibble/bing-part/part-zap?q=value'
+    , 'interpolates partial variable and keeps path unmodified when no leading slash')
+  t.equal(rhumb.interpolate('/wibble(/{foo}-part/part-{bar}/)?q=value', { foo: 'bing', bar: 'zap' }), '/wibble/bing-part/part-zap/?q=value'
+    , 'interpolates partial variable and keeps leading and trailing slash when provided')
+  t.equal(rhumb.interpolate('wibble(/{foo}-part/part-{bar}/)?q=value', { foo: 'bing', bar: 'zap' }), 'wibble/bing-part/part-zap/?q=value'
+    , 'interpolates partial variable and keeps trailing slash when provided')
+})
+
+test('Interpolating should drop optional and nested optional parts that contain an empty, null, undefined and missing partial variables', function (t) {
+  t.plan(24)
+
+  var cases = [
+        {
+          params: { foo: '', bar: 'wobble' }
+        , message: 'returns path without the optional part when partial variable is empty'
+        }
+      , {
+          params: { bar: 'wobble' }
+        , message: 'returns path without the optional part when partial variable is missing'
+        }
+      , {
+          params: { foo: null, bar: 'wobble' }
+        , message: 'returns path without the optional part when partial variable is null'
+        }
+      , {
+          params: { foo: undefined, bar: 'wobble' }
+        , message: 'returns path without the optional part when partial variable is undefined'
+        }
+      ]
+
+  cases.forEach(function (testCase) {
+    t.equal(rhumb.interpolate('/wibble(/{foo}-end)', testCase.params), '/wibble'
+      , testCase.message)
+  })
+
+  cases.forEach(function (testCase) {
+    t.equal(rhumb.interpolate('/wibble(/start-{foo})', testCase.params), '/wibble'
+      , testCase.message)
+  })
+
+  cases.forEach(function (testCase) {
+    t.equal(rhumb.interpolate('/wibble(/start-{foo}-end)', testCase.params), '/wibble'
+      , testCase.message)
+  })
+
+  cases.forEach(function (testCase) {
+    t.equal(rhumb.interpolate('/wibble(/{foo}-part)', testCase.params), '/wibble'
+      , testCase.message)
+  })
+
+  cases.forEach(function (testCase) {
+    t.equal(rhumb.interpolate('/wibble(/{foo}-{bar}/wobble)', testCase.params), '/wibble'
+      , testCase.message)
+  })
+
+  cases.forEach(function (testCase) {
+    t.equal(rhumb.interpolate('/wibble(/{foo}-{bar}/part-{bar})', testCase.params), '/wibble'
+      , testCase.message)
+  })
+})

--- a/test/interpolating/validation.test.js
+++ b/test/interpolating/validation.test.js
@@ -1,0 +1,334 @@
+var test = require('tape')
+  , rhumb = require('../../src/rhumb')
+
+test('Interpolating should not throw errors for valid empty paths', function (t) {
+  t.plan(2)
+
+  t.doesNotThrow(function () {
+    rhumb.interpolate('/', {})
+  }, 'does not throw as path is known to be valid')
+
+  t.doesNotThrow(function () {
+    rhumb.interpolate('', {})
+  }, 'does not throw as path is known to be valid')
+})
+
+test('Interpolating should not throw errors for valid fixed paths', function (t) {
+  t.plan(8)
+
+  t.doesNotThrow(function () {
+    rhumb.interpolate('/foo', {})
+  }, 'does not throw as path is known to be valid')
+
+  t.doesNotThrow(function () {
+    rhumb.interpolate('/foo/', {})
+  }, 'does not throw as path is known to be valid')
+
+  t.doesNotThrow(function () {
+    rhumb.interpolate('foo', {})
+  }, 'does not throw as path is known to be valid')
+
+  t.doesNotThrow(function () {
+    rhumb.interpolate('foo/', {})
+  }, 'does not throw as path is known to be valid')
+
+  t.doesNotThrow(function () {
+    rhumb.interpolate('/foo/bar', {})
+  }, 'does not throw as path is known to be valid')
+
+  t.doesNotThrow(function () {
+    rhumb.interpolate('/foo/bar/', {})
+  }, 'does not throw as path is known to be valid')
+
+  t.doesNotThrow(function () {
+    rhumb.interpolate('foo/bar', {})
+  }, 'does not throw as path is known to be valid')
+
+  t.doesNotThrow(function () {
+    rhumb.interpolate('foo/bar/', {})
+  }, 'does not throw as path is known to be valid')
+})
+
+test('Interpolating should not throw errors for valid fixed optional and nested paths', function (t) {
+  t.plan(8)
+
+  t.doesNotThrow(function () {
+    rhumb.interpolate('/foo(/bar)', {})
+  }, 'does not throw as path is known to be valid')
+
+  t.doesNotThrow(function () {
+    rhumb.interpolate('/foo(/bar/)', {})
+  }, 'does not throw as path is known to be valid')
+
+  t.doesNotThrow(function () {
+    rhumb.interpolate('foo(/bar)', {})
+  }, 'does not throw as path is known to be valid')
+
+  t.doesNotThrow(function () {
+    rhumb.interpolate('foo(/bar/)', {})
+  }, 'does not throw as path is known to be valid')
+
+  t.doesNotThrow(function () {
+    rhumb.interpolate('/foo(/bar(/bing))', {})
+  }, 'does not throw as path is known to be valid')
+
+  t.doesNotThrow(function () {
+    rhumb.interpolate('/foo(/bar(/bing/))', {})
+  }, 'does not throw as path is known to be valid')
+
+  t.doesNotThrow(function () {
+    rhumb.interpolate('foo(/bar(/bing))', {})
+  }, 'does not throw as path is known to be valid')
+
+  t.doesNotThrow(function () {
+    rhumb.interpolate('foo(/bar(/bing/))', {})
+  }, 'does not throw as path is known to be valid')
+})
+
+test('Interpolating should not throw errors for slashes before valid fixed optional and nested paths', function (t) {
+  t.plan(4)
+
+  t.doesNotThrow(function () {
+    rhumb.interpolate('/foo/(/bar/)', {})
+  }, 'does not throw as path is known to be valid')
+
+  t.doesNotThrow(function () {
+    rhumb.interpolate('foo/(/bar/)', {})
+  }, 'does not throw as path is known to be valid')
+
+  t.doesNotThrow(function () {
+    rhumb.interpolate('/foo/(/bar(/bing/))', {})
+  }, 'does not throw as path is known to be valid')
+
+  t.doesNotThrow(function () {
+    rhumb.interpolate('foo/(/bar(/bing/))', {})
+  }, 'does not throw as path is known to be valid')
+})
+
+test('Interpolating should only throw errors for empty, null, undefined and missing variables', function (t) {
+  t.plan(16)
+
+  var cases = [
+        {
+          params: { foo: '', bar: 'wobble' }
+        , expectedError: /Invalid parameter: "foo" is an empty value/
+        , message: 'throws an error as required variable is empty'
+        }
+      , {
+          params: { bar: 'wobble' }
+        , expectedError: /Invalid parameter: "foo" is not supplied/
+        , message: 'throws an error as required variable is missing'
+        }
+      , {
+          params: { foo: null, bar: 'wobble' }
+        , expectedError: /Invalid parameter: "foo" is null/
+        , message: 'throws an error as required variable is null'
+        }
+      , {
+          params: { foo: undefined, bar: 'wobble' }
+        , expectedError: /Invalid parameter: "foo" is undefined/
+        , message: 'throws an error as required variable is undefined'
+        }
+      ]
+
+  cases.forEach(function (testCase) {
+    t.throws(function () {
+      rhumb.interpolate('/{foo}', testCase.params)
+    }, testCase.expectedError, testCase.message)
+  })
+
+  cases.forEach(function (testCase) {
+    t.throws(function () {
+      rhumb.interpolate('/{foo}/wobble', testCase.params)
+    }, testCase.expectedError, testCase.message)
+  })
+
+  cases.forEach(function (testCase) {
+    t.throws(function () {
+      rhumb.interpolate('/wibble/{foo}', testCase.params)
+    }, testCase.expectedError, testCase.message)
+  })
+
+  cases.forEach(function (testCase) {
+    t.throws(function () {
+      rhumb.interpolate('/wibble/{foo}/{bar}/wobble', testCase.params)
+    }, testCase.expectedError, testCase.message)
+  })
+})
+
+test('Interpolating should throw only errors for empty, null, undefined and missing partial variables', function (t) {
+  t.plan(24)
+
+  var cases = [
+        {
+          params: { foo: '', bar: 'wobble' }
+        , expectedError: /Invalid parameter: "foo" is an empty value/
+        , message: 'throws an error as required partial variable is empty'
+        }
+      , {
+          params: { bar: 'wobble' }
+        , expectedError: /Invalid parameter: "foo" is not supplied/
+        , message: 'throws an error as required partial variable is missing'
+        }
+      , {
+          params: { foo: null, bar: 'wobble' }
+        , expectedError: /Invalid parameter: "foo" is null/
+        , message: 'throws an error as required partial variable is null'
+        }
+      , {
+          params: { foo: undefined, bar: 'wobble' }
+        , expectedError: /Invalid parameter: "foo" is undefined/
+        , message: 'throws an error as required partial variable is undefined'
+        }
+      ]
+
+  cases.forEach(function (testCase) {
+    t.throws(function () {
+      rhumb.interpolate('/{foo}-end', testCase.params)
+    }, testCase.expectedError, testCase.message)
+  })
+
+  cases.forEach(function (testCase) {
+    t.throws(function () {
+      rhumb.interpolate('/start-{foo}', testCase.params)
+    }, testCase.expectedError, testCase.message)
+  })
+
+  cases.forEach(function (testCase) {
+    t.throws(function () {
+      rhumb.interpolate('/start-{foo}-end', testCase.params)
+    }, testCase.expectedError, testCase.message)
+  })
+
+  cases.forEach(function (testCase) {
+    t.throws(function () {
+      rhumb.interpolate('/wibble/{foo}-part', testCase.params)
+    }, testCase.expectedError, testCase.message)
+  })
+
+  cases.forEach(function (testCase) {
+    t.throws(function () {
+      rhumb.interpolate('/wibble/{foo}-part/wobble', testCase.params)
+    }, testCase.expectedError, testCase.message)
+  })
+
+  cases.forEach(function (testCase) {
+    t.throws(function () {
+      rhumb.interpolate('/wibble/{foo}-{bar}/wobble', testCase.params)
+    }, testCase.expectedError, testCase.message)
+  })
+})
+
+test('Interpolating should not throw errors when optional and nested optional parts contain an empty, null, undefined and missing variables', function (t) {
+  t.plan(20)
+
+  var cases = [
+        {
+          params: { foo: 'bing', bar: 'wobble' }
+        , message: 'does not throw as all variables are found'
+        }
+      , {
+          params: { foo: '', bar: 'wobble' }
+        , message: 'does not throw as optional path can be dropped when variable is empty'
+        }
+      , {
+          params: { bar: 'wobble' }
+        , message: 'does not throw as optional path can be dropped when variable is missing'
+        }
+      , {
+          params: { foo: null, bar: 'wobble' }
+        , message: 'does not throw as optional path can be dropped when variable is null'
+        }
+      , {
+          params: { foo: undefined, bar: 'wobble' }
+        , message: 'does not throw as optional path can be dropped when variable is undefined'
+        }
+      ]
+
+  cases.forEach(function (testCase) {
+    t.doesNotThrow(function () {
+      rhumb.interpolate('/wibble(/{foo})', testCase.params)
+    }, testCase.message)
+  })
+
+  cases.forEach(function (testCase) {
+    t.doesNotThrow(function () {
+      rhumb.interpolate('/wibble(/{foo}/wobble)', testCase.params)
+    }, testCase.message)
+  })
+
+  cases.forEach(function (testCase) {
+    t.doesNotThrow(function () {
+      rhumb.interpolate('/wibble(/{foo}/{bar})', testCase.params)
+    }, testCase.message)
+  })
+
+  cases.forEach(function (testCase) {
+    t.doesNotThrow(function () {
+      rhumb.interpolate('/wibble(/{foo}(/{bar}))', testCase.params)
+    }, testCase.message)
+  })
+})
+
+test('Interpolating should not throw errors when optional and nested optional parts contain an empty, null, undefined and missing partial variables', function (t) {
+  t.plan(30)
+
+  var cases = [
+        {
+          params: { foo: 'bing', bar: 'wobble' }
+        , message: 'does not throw as all partial variables are found'
+        }
+      , {
+          params: { foo: '', bar: 'wobble' }
+        , message: 'does not throw as optional path can be dropped when partial variable is empty'
+        }
+      , {
+          params: { bar: 'wobble' }
+        , message: 'does not throw as optional path can be dropped when partial variable is missing'
+        }
+      , {
+          params: { foo: null, bar: 'wobble' }
+        , message: 'does not throw as optional path can be dropped when partial variable is null'
+        }
+      , {
+          params: { foo: undefined, bar: 'wobble' }
+        , message: 'does not throw as optional path can be dropped when partial variable is undefined'
+        }
+      ]
+
+  cases.forEach(function (testCase) {
+    t.doesNotThrow(function () {
+      rhumb.interpolate('/wibble(/{foo}-end)', testCase.params)
+    }, testCase.message)
+  })
+
+  cases.forEach(function (testCase) {
+    t.doesNotThrow(function () {
+      rhumb.interpolate('/wibble(/start-{foo})', testCase.params)
+    }, testCase.message)
+  })
+
+  cases.forEach(function (testCase) {
+    t.doesNotThrow(function () {
+      rhumb.interpolate('/wibble(/start-{foo}-end)', testCase.params)
+    }, testCase.message)
+  })
+
+  cases.forEach(function (testCase) {
+    t.doesNotThrow(function () {
+      rhumb.interpolate('/wibble(/{foo}-part)', testCase.params)
+    }, testCase.message)
+  })
+
+  cases.forEach(function (testCase) {
+    t.doesNotThrow(function () {
+      rhumb.interpolate('/wibble(/{foo}-{bar}/wobble)', testCase.params)
+    }, testCase.message)
+  })
+
+  cases.forEach(function (testCase) {
+    t.doesNotThrow(function () {
+      rhumb.interpolate('/wibble(/{foo}-{bar}/part-{bar})', testCase.params)
+    }, testCase.message)
+  })
+})

--- a/test/interpolating/variable-paths.test.js
+++ b/test/interpolating/variable-paths.test.js
@@ -1,0 +1,171 @@
+var test = require('tape')
+  , rhumb = require('../../src/rhumb')
+
+test('Interpolating should handle single non-empty variable paths', function (t) {
+  t.plan(4)
+
+  t.equal(rhumb.interpolate('/{foo}', { foo: 'bing' }), '/bing'
+    , 'interpolates variable and keeps leading slash when provided')
+  t.equal(rhumb.interpolate('{foo}', { foo: 'bing' }), 'bing'
+    , 'interpolates variable and keeps path unmodified when no leading slash')
+  t.equal(rhumb.interpolate('/{foo}/', { foo: 'bing' }), '/bing/'
+    , 'interpolates variable and keeps leading and trailing slash when provided')
+  t.equal(rhumb.interpolate('{foo}/', { foo: 'bing' }), 'bing/'
+    , 'interpolates variable and keeps trailing slash when provided')
+})
+
+test('Interpolating should handle paths with a non-empty variable segment followed by fixed segment', function (t) {
+  t.plan(4)
+
+  t.equal(rhumb.interpolate('/{foo}/wobble', { foo: 'bing' }), '/bing/wobble'
+    , 'interpolates variable and keeps leading slash when provided')
+  t.equal(rhumb.interpolate('{foo}/wobble', { foo: 'bing' }), 'bing/wobble'
+    , 'interpolates variable and keeps path unmodified when no leading slash')
+  t.equal(rhumb.interpolate('/{foo}/wobble/', { foo: 'bing' }), '/bing/wobble/'
+    , 'interpolates variable and keeps leading and trailing slash when provided')
+  t.equal(rhumb.interpolate('{foo}/wobble/', { foo: 'bing' }), 'bing/wobble/'
+    , 'interpolates variable and keeps trailing slash when provided')
+})
+
+test('Interpolating should handle paths with a non-empty variable segment preceding a fixed segment', function (t) {
+  t.plan(4)
+
+  t.equal(rhumb.interpolate('/wibble/{foo}', { foo: 'bing' }), '/wibble/bing'
+    , 'interpolates variable and keeps leading slash when provided')
+  t.equal(rhumb.interpolate('wibble/{foo}', { foo: 'bing' }), 'wibble/bing'
+    , 'interpolates variable and keeps path unmodified when no leading slash')
+  t.equal(rhumb.interpolate('/wibble/{foo}/', { foo: 'bing' }), '/wibble/bing/'
+    , 'interpolates variable and keeps leading and trailing slash when provided')
+  t.equal(rhumb.interpolate('wibble/{foo}/', { foo: 'bing' }), 'wibble/bing/'
+    , 'interpolates variable and keeps trailing slash when provided')
+})
+
+test('Interpolating should handle paths with a non-empty variable segment between fixed segments', function (t) {
+  t.plan(4)
+
+  t.equal(rhumb.interpolate('/wibble/{foo}/wobble', { foo: 'bing' }), '/wibble/bing/wobble'
+    , 'interpolates variable and keeps leading slash when provided')
+  t.equal(rhumb.interpolate('wibble/{foo}/wobble', { foo: 'bing' }), 'wibble/bing/wobble'
+    , 'interpolates variable and keeps path unmodified when no leading slash')
+  t.equal(rhumb.interpolate('/wibble/{foo}/wobble/', { foo: 'bing' }), '/wibble/bing/wobble/'
+    , 'interpolates variable and keeps leading and trailing slash when provided')
+  t.equal(rhumb.interpolate('wibble/{foo}/wobble/', { foo: 'bing' }), 'wibble/bing/wobble/'
+    , 'interpolates variable and keeps trailing slash when provided')
+})
+
+test('Interpolating should handle paths with multiple non-empty variable segments', function (t) {
+  t.plan(4)
+
+  t.equal(rhumb.interpolate('/wibble/{foo}/{bar}', { foo: 'bing', bar: 'zap' }), '/wibble/bing/zap'
+    , 'interpolates variable and keeps leading slash when provided')
+  t.equal(rhumb.interpolate('wibble/{foo}/{bar}', { foo: 'bing', bar: 'zap' }), 'wibble/bing/zap'
+    , 'interpolates variable and keeps path unmodified when no leading slash')
+  t.equal(rhumb.interpolate('/wibble/{foo}/{bar}/', { foo: 'bing', bar: 'zap' }), '/wibble/bing/zap/'
+    , 'interpolates variable and keeps leading and trailing slash when provided')
+  t.equal(rhumb.interpolate('wibble/{foo}/{bar}/', { foo: 'bing', bar: 'zap' }), 'wibble/bing/zap/'
+    , 'interpolates variable and keeps trailing slash when provided')
+})
+
+test('Interpolating should handle paths with non-empty variable segments in optional parts', function (t) {
+  t.plan(4)
+
+  t.equal(rhumb.interpolate('/wibble(/{foo})', { foo: 'bing' }), '/wibble/bing'
+    , 'interpolates variable and keeps leading slash when provided')
+  t.equal(rhumb.interpolate('wibble(/{foo})', { foo: 'bing' }), 'wibble/bing'
+    , 'interpolates variable and keeps path unmodified when no leading slash')
+  t.equal(rhumb.interpolate('/wibble(/{foo}/)', { foo: 'bing' }), '/wibble/bing/'
+    , 'interpolates variable and keeps leading and trailing slash when provided')
+  t.equal(rhumb.interpolate('wibble(/{foo}/)', { foo: 'bing' }), 'wibble/bing/'
+    , 'interpolates variable and keeps trailing slash when provided')
+})
+
+test('Interpolating should handle paths with non-empty variable segments in nested optional parts', function (t) {
+  t.plan(4)
+
+  t.equal(rhumb.interpolate('/wibble(/{foo}(/{bar}))', { foo: 'bing', bar: 'zap' }), '/wibble/bing/zap'
+    , 'interpolates variable and keeps leading slash when provided')
+  t.equal(rhumb.interpolate('wibble(/{foo}(/{bar}))', { foo: 'bing', bar: 'zap' }), 'wibble/bing/zap'
+    , 'interpolates variable and keeps path unmodified when no leading slash')
+  t.equal(rhumb.interpolate('/wibble(/{foo}(/{bar}/))', { foo: 'bing', bar: 'zap' }), '/wibble/bing/zap/'
+    , 'interpolates variable and keeps leading and trailing slash when provided')
+  t.equal(rhumb.interpolate('wibble(/{foo}(/{bar}/))', { foo: 'bing', bar: 'zap' }), 'wibble/bing/zap/'
+    , 'interpolates variable and keeps trailing slash when provided')
+})
+
+test('Interpolating should handle single non-empty variable paths with query params with query params', function (t) {
+  t.plan(8)
+
+  t.equal(rhumb.interpolate('/{foo}?q=value', { foo: 'bing' }), '/bing?q=value'
+    , 'interpolates variable and keeps leading slash when provided')
+  t.equal(rhumb.interpolate('{foo}?q=value', { foo: 'bing' }), 'bing?q=value'
+    , 'interpolates variable and keeps path unmodified when no leading slash')
+  t.equal(rhumb.interpolate('/{foo}/?q=value', { foo: 'bing' }), '/bing/?q=value'
+    , 'interpolates variable and keeps leading and trailing slash when provided')
+  t.equal(rhumb.interpolate('{foo}/?q=value', { foo: 'bing' }), 'bing/?q=value'
+    , 'interpolates variable and keeps trailing slash when provided')
+
+  t.equal(rhumb.interpolate('/{foo}/wobble?q=value', { foo: 'bing' }), '/bing/wobble?q=value'
+    , 'interpolates variable and keeps leading slash when provided')
+  t.equal(rhumb.interpolate('{foo}/wobble?q=value', { foo: 'bing' }), 'bing/wobble?q=value'
+    , 'interpolates variable and keeps path unmodified when no leading slash')
+  t.equal(rhumb.interpolate('/{foo}/wobble/?q=value', { foo: 'bing' }), '/bing/wobble/?q=value'
+    , 'interpolates variable and keeps leading and trailing slash when provided')
+  t.equal(rhumb.interpolate('{foo}/wobble/?q=value', { foo: 'bing' }), 'bing/wobble/?q=value'
+    , 'interpolates variable and keeps trailing slash when provided')
+})
+
+test('Interpolating should handle paths with non-empty variable segments in optional parts with query params', function (t) {
+  t.plan(4)
+
+  t.equal(rhumb.interpolate('/wibble(/{foo})?q=value', { foo: 'bing' }), '/wibble/bing?q=value'
+    , 'interpolates variable and keeps leading slash when provided')
+  t.equal(rhumb.interpolate('wibble(/{foo})?q=value', { foo: 'bing' }), 'wibble/bing?q=value'
+    , 'interpolates variable and keeps path unmodified when no leading slash')
+  t.equal(rhumb.interpolate('/wibble(/{foo}/)?q=value', { foo: 'bing' }), '/wibble/bing/?q=value'
+    , 'interpolates variable and keeps leading and trailing slash when provided')
+  t.equal(rhumb.interpolate('wibble(/{foo}/)?q=value', { foo: 'bing' }), 'wibble/bing/?q=value'
+    , 'interpolates variable and keeps trailing slash when provided')
+})
+
+test('Interpolating should drop optional and nested optional parts that contain an empty, null, undefined and missing variables', function (t) {
+  t.plan(16)
+
+  var cases = [
+        {
+          params: { foo: '', bar: 'wobble' }
+        , message: 'returns path without the optional part when variable is empty'
+        }
+      , {
+          params: { bar: 'wobble' }
+        , message: 'returns path without the optional part when variable is missing'
+        }
+      , {
+          params: { foo: null, bar: 'wobble' }
+        , message: 'returns path without the optional part when variable is null'
+        }
+      , {
+          params: { foo: undefined, bar: 'wobble' }
+        , message: 'returns path without the optional part when variable is undefined'
+        }
+      ]
+
+  cases.forEach(function (testCase) {
+    t.equal(rhumb.interpolate('/wibble(/{foo})', testCase.params), '/wibble'
+      , testCase.message)
+  })
+
+  cases.forEach(function (testCase) {
+    t.equal(rhumb.interpolate('/wibble(/{foo}/wobble)', testCase.params), '/wibble'
+      , testCase.message)
+  })
+
+  cases.forEach(function (testCase) {
+    t.equal(rhumb.interpolate('/wibble(/{foo}/{bar})', testCase.params), '/wibble'
+      , testCase.message)
+  })
+
+  cases.forEach(function (testCase) {
+    t.equal(rhumb.interpolate('/wibble(/{foo}(/{bar}))', testCase.params), '/wibble'
+      , testCase.message)
+  })
+})


### PR DESCRIPTION
This enables Rhumb to interpolate params to produce paths.

This does not do anything with encoding or decoding the values of
params, so params with "/" and "?" characters in the values will produce
paths that the user may not expect.  This is out of scope for this PR,
though it will definitely be fixed later.

## Motivation and Context

See [GH-18](https://github.com/websdk/rhumb/pull/18).

## How Was This Tested?

Unit tests have been created.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change follows the style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
